### PR TITLE
fixing PHP Notice log noise

### DIFF
--- a/loc-postmeta.php
+++ b/loc-postmeta.php
@@ -3,11 +3,11 @@
 
 if (!function_exists('ifset') ) {
   function ifset(&$var, $default = false) {
-      return isset($var) ? $var : $default;
+    return isset($var) ? $var : $default;
   }
 }
 
-// Add meta box to new post/post pages only 
+// Add meta box to new post/post pages only
 add_action('load-post.php', 'slocbox_setup');
 add_action('load-post-new.php', 'slocbox_setup');
 
@@ -32,7 +32,7 @@ function sloc_locbox_add_postmeta_boxes() {
       'normal',         // Context
       'default'         // Priority
     );
-  }  
+  }
 }
 
 /* Create address meta boxes to be displayed on the post editor screen. */
@@ -66,10 +66,10 @@ function sloc_location_metabox( $object, $box ) { ?>
 
     <label for="geo_latitude"><?php _e( "Latitude", 'simple-location' ); ?></label>
     <input type="text" name="geo_latitude" id="geo_latitude" value="<?php echo esc_attr( get_post_meta( $object->ID, 'geo_latitude', true ) ); ?>" size="10" />
-    
+
     <label for="geo_longitude"><?php _e( "Longitude", 'simple-location' ); ?></label>
     <input type="text" name="geo_longitude" id="geo_longitude" value="<?php echo esc_attr( get_post_meta( $object->ID, 'geo_longitude', true ) ); ?>" size="10" />
-    
+
     <label for="geo_altitude"><?php _e( "Altitude", 'simple-location' ); ?></label>
     <input type="text" name="geo_altitude" id="geo_altitude" value="<?php echo esc_attr( get_post_meta( $object->ID, 'geo_altitude', true ) ); ?>" size="10" />
     <br />
@@ -79,8 +79,8 @@ function sloc_location_metabox( $object, $box ) { ?>
 <?php }
 
 function sloc_address_metabox( $object, $box ) { ?>
-  <?php 
-    wp_nonce_field( 'address_metabox', 'address_metabox_nonce' ); 
+  <?php
+    wp_nonce_field( 'address_metabox', 'address_metabox_nonce' );
     $address = get_post_meta( $object->ID, 'mf2_adr');
     if ($address!=false) {
       $address = array_pop($address);
@@ -103,10 +103,10 @@ function sloc_address_metabox( $object, $box ) { ?>
   </p>
   <p>
    <label for="extended-address"><?php _e( "Extended Address", 'simple-location' ); ?></label>
-    <br /> 
+    <br />
     <input type="text" name="extended-address" id="extended-address" value="<?php echo ifset($address['extended-address'], ""); ?>" size="70" />
  </p>
-  <p> 
+  <p>
    <label for="locality"><?php _e( "City/Town/Village", 'simple-location' ); ?></label>
     <br />
     <input type="text" name="locality" id="locality" value="<?php echo ifset($address['locality'], ""); ?>" size="70" />
@@ -128,63 +128,57 @@ function sloc_address_metabox( $object, $box ) { ?>
 
 /* Save the meta box's post metadata. */
 function sloc_locationbox_save_post_meta( $post_id ) {
-	/*
-	 * We need to verify this came from our screen and with proper authorization,
-	 * because the save_post action can be triggered at other times.
-	 */
+  /*
+   * We need to verify this came from our screen and with proper authorization,
+   * because the save_post action can be triggered at other times.
+   */
 
-	// Check if our nonce is set.
-	if ( ! isset( $_POST['location_metabox_nonce'] ) ) {
-		return;
-	}
-	// Verify that the nonce is valid.
-	if ( ! wp_verify_nonce( $_POST['location_metabox_nonce'], 'location_metabox' ) ) {
-		return;
-	}
-	// If this is an autosave, our form has not been submitted, so we don't want to do anything.
-	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-		return;
-	}
-	// Check the user's permissions.
-	if ( isset( $_POST['post_type'] ) && 'page' == $_POST['post_type'] ) {
-		if ( ! current_user_can( 'edit_page', $post_id ) ) {
-			return;
-		}
-	} else {
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
-		}
-	}
+  // Check if our nonce is set.
+  if ( ! isset( $_POST['location_metabox_nonce'] ) ) {
+    return;
+  }
+  // Verify that the nonce is valid.
+  if ( ! wp_verify_nonce( $_POST['location_metabox_nonce'], 'location_metabox' ) ) {
+    return;
+  }
+  // If this is an autosave, our form has not been submitted, so we don't want to do anything.
+  if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+    return;
+  }
+  // Check the user's permissions.
+  if ( isset( $_POST['post_type'] ) && 'page' == $_POST['post_type'] ) {
+    if ( ! current_user_can( 'edit_page', $post_id ) ) {
+      return;
+    }
+  } else {
+    if ( ! current_user_can( 'edit_post', $post_id ) ) {
+      return;
+    }
+  }
 
-	/* OK, its safe for us to save the data now. */
-	if( !empty( $_POST[ 'geo_latitude' ] ) ) {
+  /* OK, its safe for us to save the data now. */
+  if( isset( $_POST[ 'geo_latitude' ]) && !empty( $_POST[ 'geo_latitude' ] ) ) {
     update_post_meta( $post_id, 'geo_latitude', esc_attr( sloc_clean_coordinate($_POST[ 'geo_latitude' ]) ) );
-	}
+  }
   else {
     delete_post_meta( $post_id, 'geo_latitude');
   }
-	if( !empty( $_POST[ 'geo_longitude' ] ) ) {
-    update_post_meta( $post_id, 'geo_longitude', esc_attr( sloc_clean_coordinate($_POST[ 'geo_longitude' ]) ) );
-    }
-  else {
-          delete_post_meta( $post_id, 'geo_longitude');
-  }
-	$public= $_POST[ 'geo_public' ];
-	if($public)
-	  		update_post_meta($post_id, 'geo_public', 1);
-	  	else
-	  		update_post_meta($post_id, 'geo_public', 0);
 
-  $full= $_POST[ 'geo_full' ];
-  if($full)
-        update_post_meta($post_id, 'geo_full', 1);
-      else
-        update_post_meta($post_id, 'geo_full', 0);
-  $map= $_POST[ 'geo_map' ];
-  if($map)
-        update_post_meta($post_id, 'geo_map', 1);
-      else
-        update_post_meta($post_id, 'geo_map', 0);
+  if( isset( $_POST[ 'geo_longitude' ]) && !empty( $_POST[ 'geo_longitude' ] ) ) {
+    update_post_meta( $post_id, 'geo_longitude', esc_attr( sloc_clean_coordinate($_POST[ 'geo_longitude' ]) ) );
+  }
+  else {
+    delete_post_meta( $post_id, 'geo_longitude');
+  }
+
+  $bools = array ( 'geo_public' , 'geo_full', 'geo_map' );
+  foreach ($bools as $bool ) {
+    if (isset( $_POST[ $bool ]) && !empty($_POST[ $bool ]))
+      update_post_meta($post_id, $bool, 1);
+    else
+      update_post_meta($post_id, $bool, 0);
+  }
+
 }
 
 add_action( 'save_post', 'sloc_locationbox_save_post_meta' );
@@ -209,7 +203,7 @@ function sloc_addressbox_save_post_meta( $post_id ) {
   }
   // Check the user's permissions.
   if ( isset( $_POST['post_type'] ) && 'page' == $_POST['post_type'] ) {
-    if ( ! current_user_can( 'edit_page', $post_id ) ) {  
+    if ( ! current_user_can( 'edit_page', $post_id ) ) {
       return;
     }
   } else {
@@ -217,38 +211,39 @@ function sloc_addressbox_save_post_meta( $post_id ) {
       return;
     }
   }
-  $lookup= $_POST[ 'geo_lookup' ];
+
+
+  $lookup = ( isset($_POST[ 'geo_lookup' ]) && !empty($_POST[ 'geo_lookup' ])) ? true : false ;
   $adr = array();
   if($lookup) {
-    if ( !empty( $_POST[ 'geo_latitude' ] ) && !empty( $_POST[ 'geo_longitude' ] ) ) {
-        $reverse_adr = sloc_reverse_lookup($_POST['geo_latitude'], $_POST['geo_longitude']);
-        update_post_meta( $post_id, 'mf2_adr', $reverse_adr );
+    if ( isset($_POST[ 'geo_latitude' ]) && !empty( $_POST[ 'geo_latitude' ] ) && isset($_POST[ 'geo_longitude' ]) && !empty( $_POST[ 'geo_longitude' ] ) ) {
+      $reverse_adr = sloc_reverse_lookup($_POST['geo_latitude'], $_POST['geo_longitude']);
+      update_post_meta( $post_id, 'mf2_adr', $reverse_adr );
     }
-   update_post_meta($post_id, 'geo_lookup', 0);
+    update_post_meta($post_id, 'geo_lookup', 0);
   }
   else {
-    if( !empty( $_POST[ 'geo_address' ] ) ) {
+    if( isset($_POST[ 'geo_address' ]) && !empty( $_POST[ 'geo_address' ] ) )
       update_post_meta($post_id, 'geo_address', sanitize_text_field($_POST[ 'geo_address']) );
-    } 
-    else {
-    update_post_meta($post_id, 'geo_address', $reverse_adr['name'] );
-    }
-   if( !empty( $_POST[ 'street-address' ] ) ) {
-     $adr['street-address'] = sanitize_text_field($_POST[ 'street-address' ]);
-   }
-   if( !empty( $_POST[ 'extended-address' ] ) ) {
-    $adr['extended-address'] = sanitize_text_field($_POST[ 'extended-address' ]);
-   }
-   if( !empty( $_POST[ 'locality' ] ) ) {
-    $adr['locality'] = sanitize_text_field($_POST[ 'locality' ]);
-   }
-   if( !empty( $_POST[ 'region' ] ) ) {
-    $adr['region'] = sanitize_text_field($_POST[ 'region' ]);
-   }
-   if( !empty( $_POST[ 'country-name' ] ) ) {
-    $adr['country-name'] = sanitize_text_field($_POST[ 'country-name' ]);
-   }
-  update_post_meta( $post_id, 'mf2_adr', $adr );
+    else
+      update_post_meta($post_id, 'geo_address', $reverse_adr['name'] );
+
+    if( isset($_POST[ 'street-address' ]) && !empty( $_POST[ 'street-address' ] ) )
+      $adr['street-address'] = sanitize_text_field($_POST[ 'street-address' ]);
+
+    if( isset($_POST[ 'extended-address' ]) && !empty( $_POST[ 'extended-address' ] ) )
+      $adr['extended-address'] = sanitize_text_field($_POST[ 'extended-address' ]);
+
+    if( isset($_POST[ 'locality' ]) && !empty( $_POST[ 'locality' ] ) )
+      $adr['locality'] = sanitize_text_field($_POST[ 'locality' ]);
+
+    if( isset($_POST[ 'region' ]) && !empty( $_POST[ 'region' ] ) )
+      $adr['region'] = sanitize_text_field($_POST[ 'region' ]);
+
+    if( isset($_POST[ 'country-name' ]) && !empty( $_POST[ 'country-name' ] ) )
+      $adr['country-name'] = sanitize_text_field($_POST[ 'country-name' ]);
+
+    update_post_meta( $post_id, 'mf2_adr', $adr );
   }
 }
 


### PR DESCRIPTION
I've added  isset() before the !empty check because in case the $_POST value is unset, it may generate  noise in log like:

```
PHP Notice:  Undefined index: geo_public in plugins/simple-location/loc-postmeta.php on line 173
PHP Notice:  Undefined index: geo_full in plugins/simple-location/loc-postmeta.php on line 179
PHP Notice:  Undefined index: geo_map in plugins/simple-location/loc-postmeta.php on line 184
PHP Notice:  Undefined index: geo_lookup in plugins/simple-location/loc-postmeta.php on line 221
```

I also replaced the 3x copy paste with a loop for the checkbox tests.