### PR TITLE
NPM and Grunt related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,21 +10,21 @@ module.exports = function(grunt) {
       }
     },
 
-    sass: {                              // Task
-      dev: {                            // Target
-        options: {                       // Target options
+    sass: {
+      dev: {
+        options: {
           style: 'expanded'
         },
-        files: {                         // Dictionary of files
-          'css/location.css': 'sass/main.scss'       // 'destination': 'source'
+        files: {
+          'css/location.css': 'sass/main.scss'
         }
       },
-      dist: {                            // Target
-        options: {                       // Target options
+      dist: {
+        options: {
           style: 'compressed'
         },
-        files: {                         // Dictionary of files
-          'css/location.min.css': 'sass/main.scss'       // 'destination': 'source'
+        files: {
+          'css/location.min.css': 'sass/main.scss'
         }
       }
     },
@@ -53,16 +53,17 @@ module.exports = function(grunt) {
     makepot: {
       target: {
         options: {
-	  mainFile: 'simple-location.php', // Main project file.
-          domainPath: '/languages',                   // Where to save the POT file.
+	  mainFile: 'simple-location.php',
+          domainPath: '/languages',
           potFilename: 'simple-location.pot',
-          type: 'wp-plugin',                // Type of project (wp-plugin or wp-theme).
-          updateTimestamp: true             // Whether the POT-Creation-Date should be updated without other changes.
+          type: 'wp-plugin',
+          updateTimestamp: true
         }
       }
     }
   });
 
+  // Load plugins.
   grunt.loadNpmTasks('grunt-wp-readme-to-markdown');
   grunt.loadNpmTasks('grunt-wp-i18n');
   grunt.loadNpmTasks('grunt-contrib-sass');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
 module.exports = function(grunt) {
+
   // Project configuration.
   grunt.initConfig({
     wp_readme_to_markdown: {
@@ -7,63 +8,63 @@ module.exports = function(grunt) {
           'README.md': 'readme.txt'
         }
       }
-     },
+    },
+
     sass: {                              // Task
-       dev: {                            // Target
-         options: {                       // Target options
-             style: 'expanded'
-             },
-          files: {                         // Dictionary of files
-        'css/location.css': 'sass/main.scss',       // 'destination': 'source'
-         }
-	},
-       dist: {                            // Target
-         options: {                       // Target options
-             style: 'compressed'
-             },
-          files: {                         // Dictionary of files
-        'css/location.min.css': 'sass/main.scss',       // 'destination': 'source'
-         }
-	}
-  },
-
- copy: {
-           main: {
-               options: {
-                   mode: true
-               },
-               src: [
-                   '**',
-                   '!node_modules/**',
-                   '!build/**',
-                   '!.git/**',
-                   '!Gruntfile.js',
-                   '!package.json',
-                   '!.gitignore',
-                   '!sass/.sass-cache/**',
-       '!syn.css.map',
-       '!syn.min.css.map'
-               ],
-               dest: 'build/trunk/'
-           }
-       },
-
-
-   makepot: {
-        target: {
-            options: {
-		mainFile: 'simple-location.php', // Main project file.
-                domainPath: '/languages',                   // Where to save the POT file.
-                potFilename: 'simple-location.pot',
-                type: 'wp-plugin',                // Type of project (wp-plugin or wp-theme).
-                updateTimestamp: true             // Whether the POT-Creation-Date should be updated without other changes.
-            	}
-            }
+      dev: {                            // Target
+        options: {                       // Target options
+          style: 'expanded'
+        },
+        files: {                         // Dictionary of files
+          'css/location.css': 'sass/main.scss'       // 'destination': 'source'
+        }
+      },
+      dist: {                            // Target
+        options: {                       // Target options
+          style: 'compressed'
+        },
+        files: {                         // Dictionary of files
+          'css/location.min.css': 'sass/main.scss'       // 'destination': 'source'
+        }
       }
+    },
+
+    copy: {
+      main: {
+        options: {
+          mode: true
+        },
+        src: [
+          '**',
+          '!node_modules/**',
+          '!build/**',
+          '!.git/**',
+          '!Gruntfile.js',
+          '!package.json',
+          '!.gitignore',
+          '!sass/.sass-cache/**',
+          '!syn.css.map',
+          '!syn.min.css.map'
+        ],
+        dest: 'build/trunk/'
+      }
+    },
+
+    makepot: {
+      target: {
+        options: {
+	  mainFile: 'simple-location.php', // Main project file.
+          domainPath: '/languages',                   // Where to save the POT file.
+          potFilename: 'simple-location.pot',
+          type: 'wp-plugin',                // Type of project (wp-plugin or wp-theme).
+          updateTimestamp: true             // Whether the POT-Creation-Date should be updated without other changes.
+        }
+      }
+    }
   });
 
   grunt.loadNpmTasks('grunt-wp-readme-to-markdown');
-  grunt.loadNpmTasks( 'grunt-wp-i18n' );
+  grunt.loadNpmTasks('grunt-wp-i18n');
   grunt.loadNpmTasks('grunt-contrib-sass');
   grunt.loadNpmTasks('grunt-contrib-copy');
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "simple-location",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/dshanske/simple-location.git"
+  },
+  "license": "GPL-2.0",
+  "bugs": {
+    "url": "https://github.com/dshanske/simple-location/issues"
+  },
+  "devDependencies": {
+    "grunt": "~1.0.1",
+    "grunt-wp-i18n": "~0.5.4",
+    "grunt-contrib-sass": "~1.0.0",
+    "grunt-contrib-copy": "~1.0.0",
+    "grunt-wp-readme-to-markdown": "~2.0.1"
+  }
+}


### PR DESCRIPTION
This should make setting up the project easier. Unfortunately https://github.com/wpreadme2markdown/wp-readme-to-markdown doesn't package for npm, and so we'll have to make that upstream change first.