### PR TITLE
Geo_Provider_OSM: Add missing `?:' in reverse_lookup()

### DIFF
--- a/includes/class-geo-provider-osm.php
+++ b/includes/class-geo-provider-osm.php
@@ -23,7 +23,7 @@ class Geo_Provider_OSM extends Geo_Provider {
 		$street = ifset( $address['house_number'], '' ) . ' ';
 		$street .= ifset( $address['road'] ) ?: ifset( $address['highway'] ) ?: ifset( $address['footway'] ) ?: '';
 		$addr = array(
-			'name' => ifset( $address['attraction'] ) ?: ifset( $address['building'] ) ?: ifset( $address['hotel'] ) ifset( $address['address29'] ) ?: ifset( $address['address26'] ) ?: null,
+			'name' => ifset( $address['attraction'] ) ?: ifset( $address['building'] ) ?: ifset( $address['hotel'] ) ?: ifset( $address['address29'] ) ?: ifset( $address['address26'] ) ?: null,
 			'street-address' => $street,
 			'extended-address' => ifset( $address['boro'] ) ?: ifset( $address['neighbourhood'] ) ?: ifset( $address['suburb'] ) ?: null,
 			'locality' => ifset( $address['hamlet'] ) ?: ifset( $address['village'] ) ?: ifset( $address['town'] ) ?: ifset( $address['city'] ) ?: null,


### PR DESCRIPTION
Without this the following error shows on every page:

    Parse error: syntax error, unexpected 'ifset' (T_STRING),
    expecting ')' in /var/www/html/wp-content/plugins/simple-
    location/includes/class-geo-provider-osm.php on line 26