### PR TITLE
Major Fixes

### DIFF
--- a/includes/class-geo-data.php
+++ b/includes/class-geo-data.php
@@ -169,7 +169,7 @@ class WP_Geo_Data {
 		if ( ! is_single() ) {
 			return;
 		}
-		$geo = self::get_geodata( $post );
+		$geo = self::get_geodata( get_the_id() );
 		if ( ! $geo ) {
 			return;
 		}
@@ -670,4 +670,32 @@ if ( ! function_exists( 'wp_exif_gps_convert' ) ) {
 	}
 }
 
+function dec_to_dms( $latitude, $longitude ) {
+	$latitudedirection  = $latitude < 0 ? 'S' : 'N';
+	$longitudedirection = $longitude < 0 ? 'W' : 'E';
 
+	$latitudenotation  = $latitude < 0 ? '-' : '';
+	$longitudenotation = $longitude < 0 ? '-' : '';
+
+	$latitudeindegrees  = floor( abs( $latitude ) );
+	$longitudeindegrees = floor( abs( $longitude ) );
+
+	$latitudedecimal  = abs( $latitude ) - $latitudeindegrees;
+	$longitudedecimal = abs( $longitude ) - $longitudeindegrees;
+
+	$_precision       = 3;
+	$latitudeminutes  = round( $latitudedecimal * 60, $_precision );
+	$longitudeminutes = round( $longitudedecimal * 60, $_precision );
+
+	return sprintf(
+		'%s%s° %s %s %s%s° %s %s',
+		$latitudenotation,
+		$latitudeindegrees,
+		$latitudeminutes,
+		$latitudedirection,
+		$longitudenotation,
+		$longitudeindegrees,
+		$longitudeminutes,
+		$longitudedirection
+	);
+}

--- a/includes/class-geo-data.php
+++ b/includes/class-geo-data.php
@@ -436,7 +436,8 @@ class WP_Geo_Data {
 			if ( empty( $geodata['longitude'] ) ) {
 				return null;
 			}
-			$map = Loc_Config::default_reverse_provider( $geodata );
+			$map = Loc_Config::geo_provider();
+			$map->set( $geodata );
 			$adr = $map->reverse_lookup();
 			if ( array_key_exists( 'display-name', $adr ) ) {
 				$geodata['address'] = trim( $adr['display-name'] );

--- a/includes/class-geo-data.php
+++ b/includes/class-geo-data.php
@@ -176,7 +176,7 @@ class WP_Geo_Data {
 		if ( empty( $geo['public'] ) || 1 !== intval( $geo['public'] ) ) {
 			return;
 		}
-		if ( $geo['address'] ) {
+		if ( isset( $geo['address'] ) ) {
 			printf(
 				'<meta name="geo.placename" content="%s" />' . PHP_EOL,
 				esc_attr( $geo['address'] )

--- a/includes/class-geo-data.php
+++ b/includes/class-geo-data.php
@@ -486,6 +486,18 @@ class WP_Geo_Data {
 		register_meta( 'term', 'geo_longitude', $args );
 
 		$args = array(
+			'sanitize_callback' => array( 'WP_Geo_Data', 'get_numeric' ),
+			'type'              => 'int',
+			'description'       => 'Altitude',
+			'single'            => true,
+			'show_in_rest'      => false,
+		);
+		register_meta( 'post', 'geo_altitude', $args );
+		register_meta( 'comment', 'geo_altitude', $args );
+		register_meta( 'user', 'geo_altitude', $args );
+		register_meta( 'term', 'geo_altitude', $args );
+
+		$args = array(
 			'type'         => 'array',
 			'description'  => 'Weather Data',
 			'single'       => true,

--- a/includes/class-geo-provider-bing.php
+++ b/includes/class-geo-provider-bing.php
@@ -1,0 +1,61 @@
+<?php
+// Bing Geocode API Provider
+class Geo_Provider_Bing extends Geo_Provider {
+
+	public function __construct( $args = array() ) {
+		$this->name = __( 'Bing', 'simple-location' );
+		$this->slug = 'bing';
+		if ( ! isset( $args['api'] ) ) {
+			$args['api'] = get_option( 'sloc_bing_api' );
+		}
+
+		parent::__construct( $args );
+	}
+
+	public function reverse_lookup() {
+		$query = add_query_arg(
+			array(
+				'key' => $this->api,
+			),
+			sprintf( 'https://dev.virtualearth.net/REST/v1/Locations/%1$s,%2$s', $this->latitude, $this->longitude )
+		);
+		$args  = array(
+			'headers'             => array(
+				'Accept' => 'application/json',
+			),
+			'timeout'             => 10,
+			'limit_response_size' => 1048576,
+			'redirection'         => 1,
+			// Use an explicit user-agent for Simple Location
+			'user-agent'          => 'Simple Location for WordPress',
+		);
+
+		$response = wp_remote_get( $query, $args );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( ( $code / 100 ) !== 2 ) {
+			return new WP_Error( 'invalid_response', wp_remote_retrieve_body( $response ), array( 'status' => $code ) );
+		}
+		$json = json_decode( $response['body'], true );
+		if ( isset( $json['resourceSets'] ) ) {
+			$json = $json['resourceSets'][0];
+			if ( isset( $json['resources'] ) ) {
+				$json = $json['resources'][0];
+			}
+		}
+
+		$addr                 = array( 'raw' => $json );
+		$addr['display-name'] = $json['name'];
+		$addr['locality']     = ifset( $json['address']['locality'] );
+		$addr['country-name'] = ifset( $json['address']['countryRegion'] );
+		$tz                   = $this->timezone();
+		if ( $tz ) {
+			$addr = array_merge( $addr, $tz );
+		}
+		return $addr;
+	}
+}
+
+register_sloc_provider( new Geo_Provider_Bing() );

--- a/includes/class-geo-provider-google.php
+++ b/includes/class-geo-provider-google.php
@@ -64,8 +64,8 @@ class Geo_Provider_Google extends Geo_Provider {
 			if ( in_array( 'administrative_area_level_2', $component['types'], true ) ) {
 				$addr['locality'] = $component['long_name'];
 			}
-			if ( in_array( 'route', $component['type'], true ) ) {
-				$addr['street-address'] .= $component['long_name'];
+			if ( in_array( 'route', $component['types'], true ) ) {
+				$addr['street-address'] = $component['long_name'];
 			}
 		}
 

--- a/includes/class-geo-provider-google.php
+++ b/includes/class-geo-provider-google.php
@@ -1,0 +1,80 @@
+<?php
+// Google Geocode API Provider
+class Geo_Provider_Google extends Geo_Provider {
+
+	public function __construct( $args = array() ) {
+		$this->name = __( 'Google', 'simple-location' );
+		$this->slug = 'google';
+		if ( ! isset( $args['api'] ) ) {
+			$args['api'] = get_option( 'sloc_google_api' );
+		}
+
+		parent::__construct( $args );
+	}
+
+	public function reverse_lookup() {
+		$query = add_query_arg(
+			array(
+				'latlng'        => $this->latitude . ',' . $this->longitude,
+				'language'      => get_bloginfo( 'language' ),
+				'location_type' => 'ROOFTOP',
+				'result_type'   => 'street_address',
+				'key'           => $this->api,
+			),
+			'https://maps.googleapis.com/maps/api/geocode/json?'
+		);
+		$args  = array(
+			'headers'             => array(
+				'Accept' => 'application/json',
+			),
+			'timeout'             => 10,
+			'limit_response_size' => 1048576,
+			'redirection'         => 1,
+			// Use an explicit user-agent for Simple Location
+			'user-agent'          => 'Simple Location for WordPress',
+		);
+
+		$response = wp_remote_get( $query, $args );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( ( $code / 100 ) !== 2 ) {
+			return new WP_Error( 'invalid_response', wp_remote_retrieve_body( $response ), array( 'status' => $code ) );
+		}
+		$json = json_decode( $response['body'], true );
+		if ( isset( $json['results'] ) ) {
+			$data = $json['results'][0];
+		} else {
+			return array();
+		}
+		$addr                 = array( 'raw' => $json );
+		$addr['display-name'] = ifset( $data['formatted_address'] );
+		foreach ( $data['address_components'] as $component ) {
+			if ( in_array( 'administrative_area_level_1', $component['types'], true ) ) {
+				$addr['region'] = $component['long_name'];
+			}
+			if ( in_array( 'country', $component['types'], true ) ) {
+				$addr['country-name'] = $component['long_name'];
+				$addr['country-code'] = $component['short_name'];
+			}
+			if ( in_array( 'neighborhood', $component['types'], true ) ) {
+				$addr['extended-address'] = $component['long_name'];
+			}
+			if ( in_array( 'administrative_area_level_2', $component['types'], true ) ) {
+				$addr['locality'] = $component['long_name'];
+			}
+			if ( in_array( 'route', $component['type'], true ) ) {
+				$addr['street-address'] .= $component['long_name'];
+			}
+		}
+
+		$tz = $this->timezone();
+		if ( $tz ) {
+			$addr = array_merge( $addr, $tz );
+		}
+		return $addr;
+	}
+}
+
+register_sloc_provider( new Geo_Provider_Google() );

--- a/includes/class-geo-provider-nominatim.php
+++ b/includes/class-geo-provider-nominatim.php
@@ -1,8 +1,9 @@
 <?php
-// OSM Static Map Provider
-class Geo_Provider_OSM extends Geo_Provider {
+// Nominatim API Provider
+class Geo_Provider_Nominatim extends Geo_Provider {
 
 	public function __construct( $args = array() ) {
+		$this->name = __( 'Nominatim', 'simple-location' );
 		if ( ! isset( $args['api'] ) ) {
 			$args['api'] = get_option( 'sloc_mapbox_api' );
 		}
@@ -96,55 +97,6 @@ class Geo_Provider_OSM extends Geo_Provider {
 			'traffic-day-v2'        => 'Mapbox Traffic Day',
 			'traffic-night-v2'      => 'Mapbox Traffic Night',
 		);
-	}
-
-	public function get_styles() {
-		if ( empty( $this->user ) ) {
-			return array();
-		}
-		$return = $this->default_styles();
-		if ( 'mapbox' === $this->user ) {
-			return $return;
-		}
-		$url     = 'https://api.mapbox.com/styles/v1/' . $this->user . '?access_token=' . $this->api;
-		$request = wp_remote_get( $url );
-		if ( is_wp_error( $request ) ) {
-			return $request; // Bail early.
-		}
-		$body = wp_remote_retrieve_body( $request );
-		$data = json_decode( $body );
-		if ( 200 !== wp_remote_retrieve_response_code( $request ) ) {
-			return new WP_Error( '403', $data->message );
-		}
-		foreach ( $data as $style ) {
-			if ( is_object( $style ) ) {
-				$return[ $style->id ] = $style->name;
-			}
-		}
-		return $return;
-	}
-
-
-	public function get_the_map_url() {
-		return sprintf( 'http://www.openstreetmap.org/?mlat=%1$s&mlon=%2$s#map=%3$s/%1$s/%2$s', $this->latitude, $this->longitude, $this->map_zoom );
-	}
-
-	public function get_the_map( $static = true ) {
-		if ( $static ) {
-			$map  = sprintf( '<img src="%s">', $this->get_the_static_map() );
-			$link = $this->get_the_map_url();
-			return '<a href="' . $link . '">' . $map . '</a>';
-		}
-	}
-
-	public function get_the_static_map() {
-		$user = $this->user;
-		if ( array_key_exists( $this->style, $this->default_styles() ) ) {
-			$user = 'mapbox';
-		}
-		$map = sprintf( 'https://api.mapbox.com/styles/v1/%1$s/%2$s/static/pin-s(%3$s,%4$s)/%3$s,%4$s, %5$s,0,0/%6$sx%7$s?access_token=%8$s', $user, $this->style, $this->longitude, $this->latitude, $this->map_zoom, $this->width, $this->height, $this->api );
-		return $map;
-
 	}
 
 }

--- a/includes/class-geo-provider-nominatim.php
+++ b/includes/class-geo-provider-nominatim.php
@@ -3,10 +3,10 @@
 class Geo_Provider_Nominatim extends Geo_Provider {
 
 	public function __construct( $args = array() ) {
-		$this->name = __( 'Nominatim', 'simple-location' );
+		$this->name = __( 'Open Search(Nominatim) via Mapquest', 'simple-location' );
 		$this->slug = 'nominatim';
 		if ( ! isset( $args['api'] ) ) {
-			$args['api'] = get_option( 'sloc_mapbox_api' );
+			$args['api'] = get_option( 'sloc_mapquest_api' );
 		}
 
 		parent::__construct( $args );
@@ -22,8 +22,9 @@ class Geo_Provider_Nominatim extends Geo_Provider {
 				'lon'             => $this->longitude,
 				'zoom'            => $this->reverse_zoom,
 				'accept-language' => get_bloginfo( 'language' ),
+				'key'             => $this->api,
 			),
-			'https://nominatim.openstreetmap.org/reverse'
+			'https://open.mapquestapi.com/nominatim/v1/reverse.php'
 		);
 		$args  = array(
 			'headers'             => array(

--- a/includes/class-geo-provider-nominatim.php
+++ b/includes/class-geo-provider-nominatim.php
@@ -4,16 +4,9 @@ class Geo_Provider_Nominatim extends Geo_Provider {
 
 	public function __construct( $args = array() ) {
 		$this->name = __( 'Nominatim', 'simple-location' );
+		$this->slug = 'nominatim';
 		if ( ! isset( $args['api'] ) ) {
 			$args['api'] = get_option( 'sloc_mapbox_api' );
-		}
-
-		if ( ! isset( $args['user'] ) ) {
-			$args['user'] = get_option( 'sloc_mapbox_user' );
-		}
-
-		if ( ! isset( $args['style'] ) ) {
-			$args['style'] = get_option( 'sloc_mapbox_style' );
 		}
 
 		parent::__construct( $args );
@@ -100,3 +93,5 @@ class Geo_Provider_Nominatim extends Geo_Provider {
 	}
 
 }
+
+register_sloc_provider( new Geo_Provider_Nominatim() );

--- a/includes/class-geo-provider.php
+++ b/includes/class-geo-provider.php
@@ -50,39 +50,6 @@ abstract class Geo_Provider extends Sloc_Provider {
 	}
 
 	/**
-	 * Set and Validate Coordinates
-	 *
-	 * @param $lat Latitude
-	 * @param $lng Longitude
-	 * @return boolean Return False if Validation Failed
-	 */
-	public function set( $lat, $lng ) {
-		// Validate inputs
-		if ( ( ! is_numeric( $lat ) ) && ( ! is_numeric( $lng ) ) ) {
-			return false;
-		}
-		$this->latitude  = $lat;
-		$this->longitude = $lng;
-	}
-
-	/**
-	 * Get Coordinates
-	 *
-	 * @return array|boolean Array with Latitude and Longitude false if null
-	 */
-	public function get() {
-		$return              = array();
-		$return['latitude']  = $this->latitude;
-		$return['longitude'] = $this->longitude;
-		$return              = array_filter( $return );
-		if ( ! empty( $return ) ) {
-			return $return;
-		}
-		return false;
-	}
-
-
-	/**
 	 * Return an address
 	 *
 	 * @return array microformats2 address elements in an array

--- a/includes/class-geo-provider.php
+++ b/includes/class-geo-provider.php
@@ -2,6 +2,7 @@
 
 abstract class Geo_Provider {
 
+	protected $name;
 	protected $reverse_zoom;
 	protected $map_zoom;
 	protected $height;
@@ -26,26 +27,26 @@ abstract class Geo_Provider {
 	 */
 	public function __construct( $args = array() ) {
 		$defaults           = array(
-			'height'       => get_option( 'sloc_height' ),
-			'width'        => get_option( 'sloc_width' ),
-			'map_zoom'     => get_option( 'sloc_zoom' ),
 			'api'          => null,
 			'latitude'     => null,
 			'longitude'    => null,
 			'reverse_zoom' => 18,
 			'user'         => '',
-			'style'        => '',
 		);
 		$defaults           = apply_filters( 'sloc_geo_provider_defaults', $defaults );
 		$r                  = wp_parse_args( $args, $defaults );
-		$this->height       = $r['height'];
-		$this->width        = $r['width'];
-		$this->map_zoom     = $r['map_zoom'];
 		$this->reverse_zoom = $r['reverse_zoom'];
 		$this->user         = $r['user'];
-		$this->style        = $r['style'];
 		$this->api          = $r['api'];
 		$this->set( $r['latitude'], $r['longitude'] );
+	}
+
+	/**
+	 * Get Name
+	 *
+	 */
+	public function get_name() {
+		return $this->name;
 	}
 
 	/**
@@ -89,13 +90,6 @@ abstract class Geo_Provider {
 	abstract public function reverse_lookup();
 
 	/**
-	 * Return an array of styles with key being id and value being display name
-	 *
-	 * @return array
-	 */
-	abstract public function get_styles();
-
-	/**
 	 * Generate Display Name for a Reverse Address Lookup
 	 *
 	 * @param array $reverse Array of MF2 Address Properties
@@ -134,39 +128,5 @@ abstract class Geo_Provider {
 			return $return;
 		}
 		return false;
-	}
-
-		/**
-	 * Return a URL for a static map
-	 *
-	 * @return string URL of MAP
-	 *
-	 */
-	abstract public function get_the_static_map();
-
-		/**
-	 * Return a URL for a link to a map
-	 *
-	 * @return string URL of link to a map
-	 *
-	 */
-	abstract public function get_the_map_url();
-
-		/**
-	 * Return HTML code for a map
-	 *
-	 * @param boolean $static Return Static or Dynamic Map
-	 * @return string HTML marked up map
-	 */
-	abstract public function get_the_map( $static = false );
-
-		/**
-	 * Given coordinates echo the output of get_the_map
-	 *
-	 * @param boolean $static Return Static or Dynamic Map
-	 * @return echos the output
-	 */
-	public function the_map( $static = false ) {
-		return $this->get_the_map( $static );
 	}
 }

--- a/includes/class-geo-provider.php
+++ b/includes/class-geo-provider.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class Geo_Provider {
+abstract class Geo_Provider extends Sloc_Provider {
 
 	protected $name;
 	protected $reverse_zoom;

--- a/includes/class-loc-config.php
+++ b/includes/class-loc-config.php
@@ -86,6 +86,16 @@ class Loc_Config {
 		);
 		register_setting(
 			'simloc', // settings page
+			'sloc_mapquest_api', // option name
+			array(
+				'type'         => 'string',
+				'description'  => 'Mapquest API Key',
+				'show_in_rest' => false,
+				'default'      => '',
+			)
+		);
+		register_setting(
+			'simloc', // settings page
 			'sloc_openweathermap_api', // option name
 			array(
 				'type'         => 'string',
@@ -369,6 +379,16 @@ class Loc_Config {
 		$weather_provider = get_option( 'sloc_weather_provider' );
 
 		add_settings_field(
+			'mapquestapi', // id
+			__( 'MapQuest API Key', 'simple-location' ), // setting title
+			array( 'Loc_Config', 'string_callback' ), // display callback
+			'simloc', // settings page
+			'sloc_map', // settings section
+			array(
+				'label_for' => 'sloc_mapquest_api',
+			)
+		);
+		add_settings_field(
 			'googleapi', // id
 			__( 'Google Maps API Key', 'simple-location' ), // setting title
 			array( 'Loc_Config', 'string_callback' ), // display callback
@@ -528,13 +548,13 @@ class Loc_Config {
 		$text      = get_option( $name );
 		$providers = $args['providers'];
 		if ( count( $providers ) > 1 ) {
-			printf( '<select name="%1$s">', $name );
+			printf( '<select name="%1$s">', esc_attr( $name ) );
 			foreach ( $providers as $key => $value ) {
 				printf( '<option value="%1$s" %2$s>%3$s</option>', $key, selected( $text, $key ), $value ); // phpcs:ignore
 			}
 			echo '</select><br /><br />';
 		} else {
-			printf( '<input name="%1$s" type="radio" id="%1$s" value="%2$s" checked /><span>%3$s</span>', $name, key( $providers ), reset( $providers ) );
+			printf( '<input name="%1$s" type="radio" id="%1$s" value="%2$s" checked /><span>%3$s</span>', esc_attr( $name ), esc_attr( key( $providers ) ), esc_html( reset( $providers ) ) );
 		}
 	}
 
@@ -575,11 +595,10 @@ class Loc_Config {
 	}
 
 	public static function measure_callback( array $args ) {
-		$name = $args['label_for'];
-		$text = get_option( $name );
-		echo '<select name="' . esc_attr( $name ) . '">';
-		echo '<option value="metric" ' . selected( $text, 'metric' ) . '>' . __( 'Metric', 'simple-location' ) . '</option>'; // phpcs:ignore
-		echo '<option value="imperial" ' . selected( $text, 'imperial' ) . '>' . __( 'Imperial', 'simple-location' ) . '</option>'; // phpcs:ignore
+		$text = get_option( 'sloc_measurements' );
+		echo '<select name="sloc_measurements">';
+		printf( '<option value="metric" %1$s >%2$s</option>', selected( $text, 'metric', false ), __( 'Metric', 'simple-location' ) ); // phpcs:ignore
+		printf( '<option value="imperial" %1$s >%2$s</option>', selected( $text, 'imperial', false ), __( 'Imperial', 'simple-location' ) ); // phpcs:ignore
 		echo '</select><br /><br />';
 	}
 
@@ -613,7 +632,6 @@ class Loc_Config {
 
 	public static function map_provider() {
 		$option = get_option( 'sloc_map_provider' );
-		error_log( $option );
 		if ( isset( static::$maps[ $option ] ) ) {
 			return static::$maps[ $option ];
 		}
@@ -639,7 +657,7 @@ class Loc_Config {
 		return 'null';
 	}
 
-	public static function _weather_provider() {
+	public static function weather_provider() {
 		$option = get_option( 'sloc_weather_provider' );
 		if ( isset( static::$weather[ $option ] ) ) {
 			return static::$weather[ $option ];

--- a/includes/class-loc-config.php
+++ b/includes/class-loc-config.php
@@ -16,27 +16,27 @@ class Loc_Config {
 	public static function init() {
 		register_setting(
 			'simloc', // settings page
-			'sloc_default_map_provider', // option name
+			'sloc_map_provider', // option name
 			array(
 				'type'         => 'string',
 				'description'  => 'Map Provider',
 				'show_in_rest' => false,
-				'default'      => 'MapBox',
+				'default'      => 'mapbox',
 			)
 		);
 		register_setting(
 			'simloc', // settings page
-			'sloc_default_reverse_provider', // option name
+			'sloc_geo_provider', // option name
 			array(
 				'type'         => 'string',
-				'description'  => 'Reverse Lookup Provider',
+				'description'  => 'Geo Lookup Provider',
 				'show_in_rest' => false,
-				'default'      => 'Nominatim',
+				'default'      => 'nominatim',
 			)
 		);
 		register_setting(
 			'simloc', // settings page
-			'sloc_default_geolocation_provider', // option name
+			'sloc_geolocation_provider', // option name
 			array(
 				'type'         => 'string',
 				'description'  => 'Geolocation Provider',
@@ -46,12 +46,12 @@ class Loc_Config {
 		);
 		register_setting(
 			'simloc', // settings page
-			'sloc_default_weather_provider', // option name
+			'sloc_weather_provider', // option name
 			array(
 				'type'         => 'string',
 				'description'  => 'Weather Provider',
 				'show_in_rest' => false,
-				'default'      => 'OpenWeatherMap',
+				'default'      => 'openweathermap',
 			)
 		);
 		register_setting(
@@ -282,35 +282,35 @@ class Loc_Config {
 			'simloc'
 		);
 		add_settings_field(
-			'sloc_default_map_provider', // id
+			'sloc_map_provider', // id
 			__( 'Map Provider', 'simple-location' ), // setting title
 			array( 'Loc_Config', 'provider_callback' ), // display callback
 			'simloc', // settings page
 			'sloc_map', // settings section
 			array(
-				'label_for' => 'sloc_default_map_provider',
+				'label_for' => 'sloc_map_provider',
 				'providers' => self::map_providers(),
 			)
 		);
 		add_settings_field(
-			'sloc_default_reverse_provider', // id
+			'sloc_geo_provider', // id
 			__( 'Reverse Provider', 'simple-location' ), // setting title
 			array( 'Loc_Config', 'provider_callback' ), // display callback
 			'simloc', // settings page
 			'sloc_map', // settings section
 			array(
-				'label_for' => 'sloc_default_reverse_provider',
-				'providers' => self::reverse_providers(),
+				'label_for' => 'sloc_geo_provider',
+				'providers' => self::geo_providers(),
 			)
 		);
 		add_settings_field(
-			'sloc_default_geolocation_provider', // id
+			'sloc_geolocation_provider', // id
 			__( 'Geolocation Provider', 'simple-location' ), // setting title
 			array( 'Loc_Config', 'provider_callback' ), // display callback
 			'simloc', // settings page
 			'sloc_map', // settings section
 			array(
-				'label_for' => 'sloc_default_geolocation_provider',
+				'label_for' => 'sloc_geolocation_provider',
 				'providers' => self::geolocation_providers(),
 			)
 		);
@@ -365,8 +365,8 @@ class Loc_Config {
 			)
 		);
 
-		$map_provider     = get_option( 'sloc_default_map_provider' );
-		$weather_provider = get_option( 'sloc_default_weather_provider' );
+		$map_provider     = get_option( 'sloc_map_provider' );
+		$weather_provider = get_option( 'sloc_weather_provider' );
 
 		add_settings_field(
 			'googleapi', // id
@@ -376,7 +376,7 @@ class Loc_Config {
 			'sloc_map', // settings section
 			array(
 				'label_for' => 'sloc_google_api',
-				'class'     => ( 'Google' === $map_provider ) ? '' : 'hidden',
+				'class'     => ( 'google' === $map_provider ) ? '' : 'hidden',
 			)
 		);
 		add_settings_field(
@@ -388,7 +388,7 @@ class Loc_Config {
 			array(
 				'label_for' => 'sloc_google_style',
 				'provider'  => new Map_Provider_Google(),
-				'class'     => ( 'Google' === $map_provider ) ? '' : 'hidden',
+				'class'     => ( 'google' === $map_provider ) ? '' : 'hidden',
 			)
 		);
 		add_settings_field(
@@ -399,7 +399,7 @@ class Loc_Config {
 			'sloc_map', // settings section
 			array(
 				'label_for' => 'sloc_bing_api',
-				'class'     => ( 'Bing' === $map_provider ) ? '' : 'hidden',
+				'class'     => ( 'bing' === $map_provider ) ? '' : 'hidden',
 
 			)
 		);
@@ -412,7 +412,7 @@ class Loc_Config {
 			array(
 				'label_for' => 'sloc_bing_style',
 				'provider'  => new Map_Provider_Bing(),
-				'class'     => ( 'Bing' === $map_provider ) ? '' : 'hidden',
+				'class'     => ( 'bing' === $map_provider ) ? '' : 'hidden',
 			)
 		);
 		add_settings_field(
@@ -423,7 +423,7 @@ class Loc_Config {
 			'sloc_map', // settings section
 			array(
 				'label_for' => 'sloc_mapbox_api',
-				'class'     => ( 'Mapbox' === $map_provider ) ? '' : 'hidden',
+				'class'     => ( 'mapbox' === $map_provider ) ? '' : 'hidden',
 
 			)
 		);
@@ -435,7 +435,7 @@ class Loc_Config {
 			'sloc_map',
 			array(
 				'label_for' => 'sloc_mapbox_user',
-				'class'     => ( 'Mapbox' === $map_provider ) ? '' : 'hidden',
+				'class'     => ( 'mapbox' === $map_provider ) ? '' : 'hidden',
 
 			)
 		);
@@ -448,7 +448,7 @@ class Loc_Config {
 			array(
 				'label_for' => 'sloc_mapbox_style',
 				'provider'  => new Map_Provider_Mapbox(),
-				'class'     => ( 'Mapbox' === $map_provider ) ? '' : 'hidden',
+				'class'     => ( 'mapbox' === $map_provider ) ? '' : 'hidden',
 
 			)
 		);
@@ -469,13 +469,13 @@ class Loc_Config {
 			)
 		);
 		add_settings_field(
-			'sloc_default_weather_provider', // id
+			'sloc_weather_provider', // id
 			__( 'Weather Provider', 'simple-location' ), // setting title
 			array( 'Loc_Config', 'provider_callback' ), // display callback
 			'simloc', // settings page
 			'sloc_weather', // settings section
 			array(
-				'label_for' => 'sloc_default_weather_provider',
+				'label_for' => 'sloc_weather_provider',
 				'providers' => self::weather_providers(),
 			)
 		);
@@ -487,7 +487,7 @@ class Loc_Config {
 			'sloc_weather', // settings section
 			array(
 				'label_for' => 'sloc_openweathermap_api',
-				'class'     => ( 'OpenWeatherMap' === $weather_provider ) ? '' : 'hidden',
+				'class'     => ( 'openweathermap' === $weather_provider ) ? '' : 'hidden',
 
 			)
 		);
@@ -499,7 +499,7 @@ class Loc_Config {
 			'sloc_weather',
 			array(
 				'label_for' => 'sloc_openweathermap_id',
-				'class'     => ( 'OpenWeatherMap' === $weather_provider ) ? '' : 'hidden',
+				'class'     => ( 'openweathermap' === $weather_provider ) ? '' : 'hidden',
 
 			)
 		);
@@ -547,7 +547,7 @@ class Loc_Config {
 		return $return;
 	}
 
-	public static function reverse_providers() {
+	public static function geo_providers() {
 		$return = array();
 		foreach ( static::$geo as $g ) {
 			$return[ $g->get_slug() ] = esc_html( $g->get_name() );
@@ -611,53 +611,40 @@ class Loc_Config {
 
 
 
-	public static function default_map_provider( $args = array() ) {
-		$option = get_option( 'sloc_default_map_provider' );
-		$option = apply_filters( 'sloc_default_map_provider', $option );
-		if ( ! $option ) {
-			$option = 'MapBox';
+	public static function map_provider() {
+		$option = get_option( 'sloc_map_provider' );
+		error_log( $option );
+		if ( isset( static::$maps[ $option ] ) ) {
+			return static::$maps[ $option ];
 		}
-		$option = 'Map_Provider_' . $option;
-		$map    = new $option( $args );
-		return $map;
+		return null;
 	}
 
-	public static function default_reverse_provider( $args = array() ) {
-		$option = get_option( 'sloc_default_reverse_provider' );
-		$option = apply_filters( 'sloc_default_reverse_provider', $option );
-		if ( ! $option ) {
-			$option = 'Nominatim';
+	public static function geo_provider() {
+		$option = get_option( 'sloc_geo_provider' );
+		if ( isset( static::$geo[ $option ] ) ) {
+			return static::$geo[ $option ];
 		}
-		$option = 'Geo_Provider_' . $option;
-		$map    = new $option( $args );
-		return $map;
+		return null;
 	}
 
-	public static function default_geolocation_provider( $args = array() ) {
-		$option = get_option( 'sloc_default_geolocation_provider' );
+	public static function geolocation_provider() {
+		$option = get_option( 'sloc_geolocation_provider' );
 		if ( 'HTML5' === $option ) {
 			return 'null';
 		}
-		$option = apply_filters( 'sloc_default_geolocation_provider', $option );
-		$option = 'Location_Provider_' . $option;
-		try {
-			$map = new $option( $args );
-		} catch ( Exception $e ) {
-			$map = null;
+		if ( isset( static::$location [ $option ] ) ) {
+			return static::$location[ $option ];
 		}
-		return $map;
-
+		return 'null';
 	}
 
-	public static function default_weather_provider( $args = array() ) {
-		$option = get_option( 'sloc_default_weather_provider' );
-		$option = apply_filters( 'sloc_default_weather_provider', $option );
-		if ( ! $option ) {
-			$option = 'OpenWeatherMap';
+	public static function _weather_provider() {
+		$option = get_option( 'sloc_weather_provider' );
+		if ( isset( static::$weather[ $option ] ) ) {
+			return static::$weather[ $option ];
 		}
-		$option = 'Weather_Provider_' . $option;
-		$map    = new $option( $args );
-		return $map;
+		return null;
 	}
 
 

--- a/includes/class-loc-config.php
+++ b/includes/class-loc-config.php
@@ -464,7 +464,7 @@ class Loc_Config {
 			'sloc_map', // settings section
 			array(
 				'label_for' => 'sloc_google_api',
-				'class'     => ( 'google' === $map_provider ) ? '' : 'hidden',
+				'class'     => ( 'google' === $map_provider || 'google' === $geo_provider ) ? '' : 'hidden',
 			)
 		);
 		add_settings_field(
@@ -487,7 +487,7 @@ class Loc_Config {
 			'sloc_map', // settings section
 			array(
 				'label_for' => 'sloc_bing_api',
-				'class'     => ( 'bing' === $map_provider ) ? '' : 'hidden',
+				'class'     => ( 'bing' === $map_provider || 'bing' === $geo_provider ) ? '' : 'hidden',
 
 			)
 		);

--- a/includes/class-loc-config.php
+++ b/includes/class-loc-config.php
@@ -66,6 +66,27 @@ class Loc_Config {
 		);
 		register_setting(
 			'simloc', // settings page
+			'sloc_here_api', // option name
+			array(
+				'type'         => 'string',
+				'description'  => 'HERE Maps API Key',
+				'show_in_rest' => false,
+				'default'      => '',
+			)
+		);
+		register_setting(
+			'simloc', // settings page
+			'sloc_here_appid', // option name
+			array(
+				'type'         => 'string',
+				'description'  => 'Here Maps APP ID',
+				'show_in_rest' => false,
+				'default'      => '',
+			)
+		);
+
+		register_setting(
+			'simloc', // settings page
 			'sloc_mapbox_api', // option name
 			array(
 				'type'         => 'string',
@@ -152,6 +173,16 @@ class Loc_Config {
 				'description'  => 'Google Map Style',
 				'show_in_rest' => false,
 				'default'      => 'roadmap',
+			)
+		);
+		register_setting(
+			'simloc',
+			'sloc_mapquest_style',
+			array(
+				'type'         => 'string',
+				'description'  => 'Mapquest Map Style',
+				'show_in_rest' => false,
+				'default'      => 'map',
 			)
 		);
 
@@ -377,6 +408,7 @@ class Loc_Config {
 
 		$map_provider     = get_option( 'sloc_map_provider' );
 		$weather_provider = get_option( 'sloc_weather_provider' );
+		$geo_provider     = get_option( 'sloc_geo_provider' );
 
 		add_settings_field(
 			'mapquestapi', // id
@@ -386,8 +418,44 @@ class Loc_Config {
 			'sloc_map', // settings section
 			array(
 				'label_for' => 'sloc_mapquest_api',
+				'class'     => ( 'mapquest' === $map_provider || 'mapquest' === $geo_provider ) ? '' : 'hidden',
 			)
 		);
+		add_settings_field(
+			'mapqueststyle', // id
+			__( 'MapQuest Style', 'simple-location' ),
+			array( 'Loc_Config', 'style_callback' ),
+			'simloc',
+			'sloc_map',
+			array(
+				'label_for' => 'sloc_mapquest_style',
+				'provider'  => new Map_Provider_Mapquest(),
+				'class'     => ( 'mapquest' === $map_provider ) ? '' : 'hidden',
+			)
+		);
+		add_settings_field(
+			'hereapi', // id
+			__( 'HERE API Key', 'simple-location' ), // setting title
+			array( 'Loc_Config', 'string_callback' ), // display callback
+			'simloc', // settings page
+			'sloc_map', // settings section
+			array(
+				'label_for' => 'sloc_here_api',
+				'class'     => ( 'here' === $map_provider ) ? '' : 'hidden',
+			)
+		);
+		add_settings_field(
+			'hereapp', // id
+			__( 'HERE Application ID', 'simple-location' ), // setting title
+			array( 'Loc_Config', 'string_callback' ), // display callback
+			'simloc', // settings page
+			'sloc_map', // settings section
+			array(
+				'label_for' => 'sloc_here_appid',
+				'class'     => ( 'here' === $map_provider ) ? '' : 'hidden',
+			)
+		);
+
 		add_settings_field(
 			'googleapi', // id
 			__( 'Google Maps API Key', 'simple-location' ), // setting title

--- a/includes/class-loc-config.php
+++ b/includes/class-loc-config.php
@@ -17,7 +17,7 @@ class Loc_Config {
 				'type'         => 'string',
 				'description'  => 'Map Provider',
 				'show_in_rest' => false,
-				'default'      => 'OSM',
+				'default'      => 'MapBox',
 			)
 		);
 		register_setting(
@@ -27,7 +27,7 @@ class Loc_Config {
 				'type'         => 'string',
 				'description'  => 'Reverse Lookup Provider',
 				'show_in_rest' => false,
-				'default'      => 'OSM',
+				'default'      => 'Nominatim',
 			)
 		);
 		register_setting(
@@ -367,7 +367,7 @@ class Loc_Config {
 			'sloc_map',
 			array(
 				'label_for' => 'sloc_google_style',
-				'provider'  => new Geo_Provider_Google(),
+				'provider'  => new Map_Provider_Google(),
 				'class'     => ( 'Google' === $map_provider ) ? '' : 'hidden',
 			)
 		);
@@ -391,7 +391,7 @@ class Loc_Config {
 			'sloc_map',
 			array(
 				'label_for' => 'sloc_bing_style',
-				'provider'  => new Geo_Provider_Bing(),
+				'provider'  => new Map_Provider_Bing(),
 				'class'     => ( 'Bing' === $map_provider ) ? '' : 'hidden',
 			)
 		);
@@ -427,7 +427,7 @@ class Loc_Config {
 			'sloc_map',
 			array(
 				'label_for' => 'sloc_mapbox_style',
-				'provider'  => new Geo_Provider_OSM(),
+				'provider'  => new Map_Provider_Mapbox(),
 				'class'     => ( 'OSM' === $map_provider ) ? '' : 'hidden',
 
 			)
@@ -517,7 +517,7 @@ class Loc_Config {
 
 	public static function map_providers() {
 		$return = array(
-			'OSM'    => __( 'OpenStreetMap/MapBox', 'simple-location' ),
+			'MapBox' => __( 'OpenStreetMap/MapBox', 'simple-location' ),
 			'Google' => __( 'Google Maps', 'simple-location' ),
 			'Bing'   => __( 'Bing Maps', 'simple-location' ),
 		);
@@ -526,7 +526,7 @@ class Loc_Config {
 
 	public static function reverse_providers() {
 		$return = array(
-			'OSM' => __( 'OpenStreetMap/Nominatim', 'simple-location' ),
+			'Nominatim' => __( 'Nominatim', 'simple-location' ),
 		);
 		return apply_filters( 'reverse_providers', $return );
 	}
@@ -587,9 +587,9 @@ class Loc_Config {
 		$option = get_option( 'sloc_default_map_provider' );
 		$option = apply_filters( 'sloc_default_map_provider', $option );
 		if ( ! $option ) {
-			$option = 'OSM';
+			$option = 'MapBox';
 		}
-		$option = 'Geo_Provider_' . $option;
+		$option = 'Map_Provider_' . $option;
 		$map    = new $option( $args );
 		return $map;
 	}
@@ -598,7 +598,7 @@ class Loc_Config {
 		$option = get_option( 'sloc_default_reverse_provider' );
 		$option = apply_filters( 'sloc_default_reverse_provider', $option );
 		if ( ! $option ) {
-			$option = 'OSM';
+			$option = 'Nominatim';
 		}
 		$option = 'Geo_Provider_' . $option;
 		$map    = new $option( $args );

--- a/includes/class-loc-metabox.php
+++ b/includes/class-loc-metabox.php
@@ -90,7 +90,7 @@ class Loc_Metabox {
 				'sloc_location',
 				'geo_options',
 				array(
-					'lookup' => get_option( 'sloc_default_geolocation_provider' ),
+					'lookup' => get_option( 'sloc_geolocation_provider' ),
 				)
 			);
 		}

--- a/includes/class-loc-view.php
+++ b/includes/class-loc-view.php
@@ -41,10 +41,11 @@ class Loc_View {
 		$default  = apply_filters( 'simple_location_display_defaults', $defaults );
 		$args     = wp_parse_args( $args, $defaults );
 		$args     = array_merge( $loc, $args );
-		$map      = Loc_Config::default_map_provider( $args );
-		$wrap     = '<%1$s class="%2$s">%3$s</%1$s>';
-		$class    = is_array( $args['wrapper-class'] ) ? implode( ' ', $args['wrapper-class'] ) : $args['wrapper-class'];
-		$c        = '<span class="p-location">';
+		$map      = Loc_Config::map_provider();
+		$map->set( $loc );
+		$wrap  = '<%1$s class="%2$s">%3$s</%1$s>';
+		$class = is_array( $args['wrapper-class'] ) ? implode( ' ', $args['wrapper-class'] ) : $args['wrapper-class'];
+		$c     = '<span class="p-location">';
 
 		if ( $args['text'] ) {
 			$c .= $args['description'];
@@ -70,7 +71,8 @@ class Loc_View {
 	public static function get_map( $object = null, $args = array() ) {
 		$loc = WP_Geo_Data::get_geodata( $object );
 		if ( isset( $loc ) && ( 1 === $loc['public'] ) ) {
-			$map = Loc_Config::default_map_provider( array_merge( $loc, $args ) );
+			$map = Loc_Config::map_provider();
+			$map->set( $loc );
 			return $map->get_the_map();
 		}
 		return '';

--- a/includes/class-loc-view.php
+++ b/includes/class-loc-view.php
@@ -50,11 +50,12 @@ class Loc_View {
 			$c .= $args['description'];
 		}
 		// 1 is full public
-		if ( '1' === $loc['public'] ) {
-			$c .= self::get_the_geo( $loc );
-			$c .= '<a href="' . $map->get_the_map_url() . '">' . $loc['address'] . '</a>';
+		if ( 1 === $loc['public'] ) {
+			$c             .= self::get_the_geo( $loc );
+			$loc['address'] = isset( $loc['address'] ) ? $loc['address'] : dec_to_dms( $loc['latitude'], $loc['longitude'] );
+			$c             .= '<a href="' . $map->get_the_map_url() . '">' . $loc['address'] . '</a>';
 		} else {
-			$c = $loc['address'];
+			$c = isset( $loc['address'] ) ? $loc['address'] : '';
 		}
 		$c .= '</span>';
 		if ( isset( $loc['weather'] ) && $args['weather'] ) {
@@ -68,7 +69,7 @@ class Loc_View {
 
 	public static function get_map( $object = null, $args = array() ) {
 		$loc = WP_Geo_Data::get_geodata( $object );
-		if ( isset( $loc ) && ( '1' === $loc['public'] ) ) {
+		if ( isset( $loc ) && ( 1 === $loc['public'] ) ) {
 			$map = Loc_Config::default_map_provider( array_merge( $loc, $args ) );
 			return $map->get_the_map();
 		}

--- a/includes/class-location-provider.php
+++ b/includes/class-location-provider.php
@@ -30,22 +30,6 @@ abstract class Location_Provider extends Sloc_Provider {
 	}
 
 	/**
-	 * Set and Validate Coordinates
-	 *
-	 * @param $lat Latitude
-	 * @param $lng Longitude
-	 * @return boolean Return False if Validation Failed
-	 */
-	public function set( $lat, $lng ) {
-		// Validate inputs
-		if ( ( ! is_numeric( $lat ) ) && ( ! is_numeric( $lng ) ) ) {
-			return false;
-		}
-		$this->latitude  = $lat;
-		$this->longitude = $lng;
-	}
-
-	/**
 	 * Get Coordinates
 	 *
 	 * @return array|boolean Array with Latitude and Longitude false if null

--- a/includes/class-map-provider-bing.php
+++ b/includes/class-map-provider-bing.php
@@ -1,9 +1,10 @@
 <?php
 // Bing Map Provider
-class Geo_Provider_Bing extends Geo_Provider {
+class Map_Provider_Bing extends Map_Provider {
 
 
 	public function __construct( $args = array() ) {
+		$this->name = __( 'Bing Maps', 'simple-location' );
 		if ( ! isset( $args['api'] ) ) {
 			$args['api'] = get_option( 'sloc_bing_api' );
 		}
@@ -11,23 +12,6 @@ class Geo_Provider_Bing extends Geo_Provider {
 			$args['style'] = get_option( 'sloc_bing_style' );
 		}
 		parent::__construct( $args );
-	}
-
-	public function reverse_lookup() {
-		$response = wp_remote_get( 'http://dev.virtualearth.net/REST/v1/Locations/' . $this->latitude . ',' . $this->longitude . '&key=' . $this->api );
-		$json     = json_decode( $response['body'], true );
-		//$address = $json['results'][0]['address_components'];
-		$addr = array(
-			//	'name' => $json['results'][0]['formatted_address'],
-				'latitude' => $this->latitude,
-			'longitude'    => $this->longitude,
-			'raw'          => $json,
-		);
-		$addr = array_filter( $addr );
-		// $addr['display-name'] = $this->display_name( $addr );
-		$tz   = $this->timezone( $this->latitude, $this->longitude );
-		$addr = array_merge( $addr, $tz );
-		return $addr;
 	}
 
 	public function get_styles() {
@@ -43,12 +27,12 @@ class Geo_Provider_Bing extends Geo_Provider {
 
 	// Return code for map
 	public function get_the_static_map() {
-		$map = sprintf( 'http://dev.virtualearth.net/REST/v1/Imagery/Map/%1$s/%2$s,%3$s/%4$s?pushpin=%2$s,%3$s&mapSize=%5$s,%6$s&key=%7$s', $this->style, $this->latitude, $this->longitude, $this->map_zoom, $this->width, $this->height, $this->api );
+		$map = sprintf( 'https://dev.virtualearth.net/REST/v1/Imagery/Map/%1$s/%2$s,%3$s/%4$s?pushpin=%2$s,%3$s&mapSize=%5$s,%6$s&key=%7$s', $this->style, $this->latitude, $this->longitude, $this->map_zoom, $this->width, $this->height, $this->api );
 		return $map;
 	}
 
 	public function get_the_map_url() {
-		return sprintf( 'http://bing.com/maps/default.aspx?cp=%1$s,%2$s&lvl=%3$s', $this->latitude, $this->longitude, $this->map_zoom );
+		return sprintf( 'https://bing.com/maps/default.aspx?cp=%1$s,%2$s&lvl=%3$s', $this->latitude, $this->longitude, $this->map_zoom );
 	}
 
 	// Return code for map
@@ -58,5 +42,4 @@ class Geo_Provider_Bing extends Geo_Provider {
 		$c    = '<a href="' . $link . '"><img src="' . $map . '" /></a>';
 		return $c;
 	}
-
 }

--- a/includes/class-map-provider-bing.php
+++ b/includes/class-map-provider-bing.php
@@ -5,6 +5,7 @@ class Map_Provider_Bing extends Map_Provider {
 
 	public function __construct( $args = array() ) {
 		$this->name = __( 'Bing Maps', 'simple-location' );
+		$this->slug = 'bing';
 		if ( ! isset( $args['api'] ) ) {
 			$args['api'] = get_option( 'sloc_bing_api' );
 		}
@@ -43,3 +44,5 @@ class Map_Provider_Bing extends Map_Provider {
 		return $c;
 	}
 }
+
+register_sloc_provider( new Map_Provider_Bing() );

--- a/includes/class-map-provider-google.php
+++ b/includes/class-map-provider-google.php
@@ -5,6 +5,7 @@ class Map_Provider_Google extends Map_Provider {
 
 	public function __construct( $args = array() ) {
 		$this->name = __( 'Google Maps', 'simple-location' );
+		$this->slug = 'google';
 		if ( ! isset( $args['api'] ) ) {
 			$args['api'] = get_option( 'sloc_google_api' );
 		}

--- a/includes/class-map-provider-google.php
+++ b/includes/class-map-provider-google.php
@@ -1,9 +1,10 @@
 <?php
 // Google Map Provider
-class Geo_Provider_Google extends Geo_Provider {
+class Map_Provider_Google extends Map_Provider {
 
 
 	public function __construct( $args = array() ) {
+		$this->name = __( 'Google Maps', 'simple-location' );
 		if ( ! isset( $args['api'] ) ) {
 			$args['api'] = get_option( 'sloc_google_api' );
 		}
@@ -11,23 +12,6 @@ class Geo_Provider_Google extends Geo_Provider {
 			$args['style'] = get_option( 'sloc_google_style' );
 		}
 		parent::__construct( $args );
-	}
-
-	public function reverse_lookup() {
-		$response = wp_remote_get( 'https://maps.googleapis.com/maps/api/geocode/json?latlng=' . $this->latitude . ',' . $this->longitude . '&key=' . $this->api );
-		$json     = json_decode( $response['body'], true );
-		//$address = $json['results'][0]['address_components'];
-		$addr = array(
-			//	'name' => $json['results'][0]['formatted_address'],
-				'latitude' => $this->latitude,
-			'longitude'    => $this->longitude,
-			'raw'          => $json,
-		);
-		$addr = array_filter( $addr );
-		// $addr['display-name'] = $this->display_name( $addr );
-		$tz   = $this->timezone( $this->latitude, $this->longitude );
-		$addr = array_merge( $addr, $tz );
-		return $addr;
 	}
 
 	public function get_styles() {

--- a/includes/class-map-provider-google.php
+++ b/includes/class-map-provider-google.php
@@ -42,3 +42,6 @@ class Map_Provider_Google extends Map_Provider {
 	}
 
 }
+
+register_sloc_provider( new Map_Provider_Google() );
+

--- a/includes/class-map-provider-here.php
+++ b/includes/class-map-provider-here.php
@@ -1,0 +1,44 @@
+<?php
+// HERE Map Provider
+class Map_Provider_Here extends Map_Provider {
+
+	protected $appid;
+	public function __construct( $args = array() ) {
+		$this->name = __( 'HERE Maps', 'simple-location' );
+		$this->slug = 'here';
+		if ( ! isset( $args['api'] ) ) {
+			$args['api'] = get_option( 'sloc_here_api' );
+		}
+		if ( ! isset( $args['appid'] ) ) {
+			$args['appid'] = get_option( 'sloc_here_appid' );
+		}
+		$this->appid = $args['appid'];
+		parent::__construct( $args );
+	}
+
+	public function get_styles() {
+		return array();
+	}
+
+	// Return code for map
+	public function get_the_static_map() {
+		$map = sprintf( 'https://image.maps.api.here.com/mia/1.6/?app_code=%1$s&app_id=%2$s&lat=%3$s&lon=%4$s&w=%5$s&h=%6$s', $this->api, $this->appid, $this->latitude, $this->longitude, $this->width, $this->height );
+		return $map;
+	}
+
+	public function get_the_map_url() {
+		return sprintf( 'https://wego.here.com/?map=%1$s,%2$s,%3$s', $this->latitude, $this->longitude, $this->map_zoom );
+	}
+
+	// Return code for map
+	public function get_the_map( $static = true ) {
+		$map  = $this->get_the_static_map();
+		$link = $this->get_the_map_url();
+		$c    = '<a href="' . $link . '"><img src="' . $map . '" /></a>';
+		return $c;
+	}
+
+}
+
+register_sloc_provider( new Map_Provider_Here() );
+

--- a/includes/class-map-provider-mapbox.php
+++ b/includes/class-map-provider-mapbox.php
@@ -1,0 +1,94 @@
+<?php
+// Mapbox Map Provider
+class Map_Provider_Mapbox extends Map_Provider {
+
+	public function __construct( $args = array() ) {
+		$this->name = __( 'Mapbox', 'simple-location' );
+		if ( ! isset( $args['api'] ) ) {
+			$args['api'] = get_option( 'sloc_mapbox_api' );
+		}
+
+		if ( ! isset( $args['user'] ) ) {
+			$args['user'] = get_option( 'sloc_mapbox_user' );
+		}
+
+		if ( ! isset( $args['style'] ) ) {
+			$args['style'] = get_option( 'sloc_mapbox_style' );
+		}
+
+		parent::__construct( $args );
+	}
+
+	public function default_styles() {
+		return array(
+			'streets-v10'           => 'Mapbox Streets',
+			'outdoors-v10'          => 'Mapbox Outdoor',
+			'light-v9'              => 'Mapbox Light',
+			'dark-v9'               => 'Mapbox Dark',
+			'satellite-v9'          => 'Mapbox Satellite',
+			'satellite-streets-v10' => 'Mapbox Satellite Streets',
+			'traffic-day-v2'        => 'Mapbox Traffic Day',
+			'traffic-night-v2'      => 'Mapbox Traffic Night',
+		);
+	}
+
+	public function get_styles() {
+		if ( empty( $this->user ) ) {
+			return array();
+		}
+		$return = $this->default_styles();
+		if ( 'mapbox' === $this->user ) {
+			return $return;
+		}
+		$url          = 'https://api.mapbox.com/styles/v1/' . $this->user . '?access_token=' . $this->api;
+				$args = array(
+					'headers'             => array(
+						'Accept' => 'application/json',
+					),
+					'timeout'             => 10,
+					'limit_response_size' => 1048576,
+					'redirection'         => 1,
+					// Use an explicit user-agent for Simple Location
+					'user-agent'          => 'Simple Location for WordPress',
+				);
+		$request = wp_remote_get( $url, $args );
+		if ( is_wp_error( $request ) ) {
+			return $request; // Bail early.
+		}
+		$body = wp_remote_retrieve_body( $request );
+		$data = json_decode( $body );
+		if ( 200 !== wp_remote_retrieve_response_code( $request ) ) {
+			return new WP_Error( '403', $data->message );
+		}
+		foreach ( $data as $style ) {
+			if ( is_object( $style ) ) {
+				$return[ $style->id ] = $style->name;
+			}
+		}
+		return $return;
+	}
+
+
+	public function get_the_map_url() {
+		return sprintf( 'https://www.openstreetmap.org/?mlat=%1$s&mlon=%2$s#map=%3$s/%1$s/%2$s', $this->latitude, $this->longitude, $this->map_zoom );
+	}
+
+	public function get_the_map( $static = true ) {
+		if ( $static ) {
+			$map  = sprintf( '<img src="%s">', $this->get_the_static_map() );
+			$link = $this->get_the_map_url();
+			return '<a href="' . $link . '">' . $map . '</a>';
+		}
+	}
+
+	public function get_the_static_map() {
+		$user = $this->user;
+		if ( array_key_exists( $this->style, $this->default_styles() ) ) {
+			$user = 'mapbox';
+		}
+		$map = sprintf( 'https://api.mapbox.com/styles/v1/%1$s/%2$s/static/pin-s(%3$s,%4$s)/%3$s,%4$s, %5$s,0,0/%6$sx%7$s?access_token=%8$s', $user, $this->style, $this->longitude, $this->latitude, $this->map_zoom, $this->width, $this->height, $this->api );
+		return $map;
+
+	}
+
+}

--- a/includes/class-map-provider-mapbox.php
+++ b/includes/class-map-provider-mapbox.php
@@ -4,6 +4,7 @@ class Map_Provider_Mapbox extends Map_Provider {
 
 	public function __construct( $args = array() ) {
 		$this->name = __( 'Mapbox', 'simple-location' );
+		$this->slug = 'mapbox';
 		if ( ! isset( $args['api'] ) ) {
 			$args['api'] = get_option( 'sloc_mapbox_api' );
 		}
@@ -92,3 +93,5 @@ class Map_Provider_Mapbox extends Map_Provider {
 	}
 
 }
+
+register_sloc_provider( new Map_Provider_Mapbox() );

--- a/includes/class-map-provider-mapquest.php
+++ b/includes/class-map-provider-mapquest.php
@@ -1,0 +1,49 @@
+<?php
+// MapQuest Map Provider
+class Map_Provider_Mapquest extends Map_Provider {
+
+
+	public function __construct( $args = array() ) {
+		$this->name = __( 'Mapquest Maps', 'simple-location' );
+		$this->slug = 'mapquest';
+		if ( ! isset( $args['api'] ) ) {
+			$args['api'] = get_option( 'sloc_mapquest_api' );
+		}
+		if ( ! isset( $args['style'] ) ) {
+			$args['style'] = get_option( 'sloc_mapquest_style' );
+		}
+		parent::__construct( $args );
+	}
+
+	public function get_styles() {
+		return array(
+			'map'   => __( 'Basic Map', 'simple-location' ),
+			'hyb'   => __( 'Hybrid', 'simple-location' ),
+			'sat'   => __( 'Satellite', 'simple-location' ),
+			'light' => __( 'Light', 'simple-location' ),
+			'dark'  => __( 'Dark', 'simple-location' ),
+		);
+	}
+
+	// Return code for map
+	public function get_the_static_map() {
+		$map = sprintf( 'https://open.mapquestapi.com/staticmap/v5/map?key=%1$s&center=%2$s,%3$s&size=%4$s,%5$s&type=%6$s', $this->api, $this->latitude, $this->longitude, $this->width, $this->height, $this->style );
+		return $map;
+	}
+
+	public function get_the_map_url() {
+		return sprintf( 'https://www.mapquest.com/?center=%1$s,%2$s&zoom=%3$s', $this->latitude, $this->longitude, $this->map_zoom );
+	}
+
+	// Return code for map
+	public function get_the_map( $static = true ) {
+		$map  = $this->get_the_static_map();
+		$link = $this->get_the_map_url();
+		$c    = '<a href="' . $link . '"><img src="' . $map . '" /></a>';
+		return $c;
+	}
+
+}
+
+register_sloc_provider( new Map_Provider_Mapquest() );
+

--- a/includes/class-map-provider.php
+++ b/includes/class-map-provider.php
@@ -1,17 +1,13 @@
 <?php
 
-abstract class Map_Provider {
+abstract class Map_Provider extends Sloc_Provider {
 
-	protected $name;
 	protected $reverse_zoom;
 	protected $map_zoom;
 	protected $height;
 	protected $width;
-	protected $api;
 	protected $style;
 	protected $user;
-	protected $latitude;
-	protected $longitude;
 	protected $static;
 
 	/**
@@ -43,45 +39,6 @@ abstract class Map_Provider {
 		$this->set( $r['latitude'], $r['longitude'] );
 	}
 
-	/**
-	 * Get Name
-	 *
-	 */
-	public function get_name() {
-		return $this->name;
-	}
-
-	/**
-	 * Set and Validate Coordinates
-	 *
-	 * @param $lat Latitude
-	 * @param $lng Longitude
-	 * @return boolean Return False if Validation Failed
-	 */
-	public function set( $lat, $lng ) {
-		// Validate inputs
-		if ( ( ! is_numeric( $lat ) ) && ( ! is_numeric( $lng ) ) ) {
-			return false;
-		}
-		$this->latitude  = $lat;
-		$this->longitude = $lng;
-	}
-
-	/**
-	 * Get Coordinates
-	 *
-	 * @return array|boolean Array with Latitude and Longitude false if null
-	 */
-	public function get() {
-		$return              = array();
-		$return['latitude']  = $this->latitude;
-		$return['longitude'] = $this->longitude;
-		$return              = array_filter( $return );
-		if ( ! empty( $return ) ) {
-			return $return;
-		}
-		return false;
-	}
 
 	/**
 	 * Return an array of styles with key being id and value being display name

--- a/includes/class-map-provider.php
+++ b/includes/class-map-provider.php
@@ -1,0 +1,126 @@
+<?php
+
+abstract class Map_Provider {
+
+	protected $name;
+	protected $reverse_zoom;
+	protected $map_zoom;
+	protected $height;
+	protected $width;
+	protected $api;
+	protected $style;
+	protected $user;
+	protected $latitude;
+	protected $longitude;
+	protected $static;
+
+	/**
+	 * Constructor for the Abstract Class
+	 *
+	 * The default version of this just sets the parameters
+	 *
+	 * @param string $key API Key if Needed
+	 */
+	public function __construct( $args = array() ) {
+		$defaults       = array(
+			'height'    => get_option( 'sloc_height' ),
+			'width'     => get_option( 'sloc_width' ),
+			'map_zoom'  => get_option( 'sloc_zoom' ),
+			'api'       => null,
+			'latitude'  => null,
+			'longitude' => null,
+			'user'      => '',
+			'style'     => '',
+		);
+		$defaults       = apply_filters( 'sloc_geo_provider_defaults', $defaults );
+		$r              = wp_parse_args( $args, $defaults );
+		$this->height   = $r['height'];
+		$this->width    = $r['width'];
+		$this->map_zoom = $r['map_zoom'];
+		$this->user     = $r['user'];
+		$this->style    = $r['style'];
+		$this->api      = $r['api'];
+		$this->set( $r['latitude'], $r['longitude'] );
+	}
+
+	/**
+	 * Get Name
+	 *
+	 */
+	public function get_name() {
+		return $this->name;
+	}
+
+	/**
+	 * Set and Validate Coordinates
+	 *
+	 * @param $lat Latitude
+	 * @param $lng Longitude
+	 * @return boolean Return False if Validation Failed
+	 */
+	public function set( $lat, $lng ) {
+		// Validate inputs
+		if ( ( ! is_numeric( $lat ) ) && ( ! is_numeric( $lng ) ) ) {
+			return false;
+		}
+		$this->latitude  = $lat;
+		$this->longitude = $lng;
+	}
+
+	/**
+	 * Get Coordinates
+	 *
+	 * @return array|boolean Array with Latitude and Longitude false if null
+	 */
+	public function get() {
+		$return              = array();
+		$return['latitude']  = $this->latitude;
+		$return['longitude'] = $this->longitude;
+		$return              = array_filter( $return );
+		if ( ! empty( $return ) ) {
+			return $return;
+		}
+		return false;
+	}
+
+	/**
+	 * Return an array of styles with key being id and value being display name
+	 *
+	 * @return array
+	 */
+	abstract public function get_styles();
+
+		/**
+	 * Return a URL for a static map
+	 *
+	 * @return string URL of MAP
+	 *
+	 */
+	abstract public function get_the_static_map();
+
+		/**
+	 * Return a URL for a link to a map
+	 *
+	 * @return string URL of link to a map
+	 *
+	 */
+	abstract public function get_the_map_url();
+
+		/**
+	 * Return HTML code for a map
+	 *
+	 * @param boolean $static Return Static or Dynamic Map
+	 * @return string HTML marked up map
+	 */
+	abstract public function get_the_map( $static = false );
+
+		/**
+	 * Given coordinates echo the output of get_the_map
+	 *
+	 * @param boolean $static Return Static or Dynamic Map
+	 * @return echos the output
+	 */
+	public function the_map( $static = false ) {
+		return $this->get_the_map( $static );
+	}
+}

--- a/includes/class-rest-geo.php
+++ b/includes/class-rest-geo.php
@@ -208,3 +208,4 @@ class REST_Geo {
 
 }
 
+new REST_Geo();

--- a/includes/class-rest-geo.php
+++ b/includes/class-rest-geo.php
@@ -136,7 +136,8 @@ class REST_Geo {
 				$args['width'] = $params['width'];
 			}
 
-			$map = Loc_Config::default_map_provider( $args );
+			$map = Loc_Config::map_provider();
+			$map->set( $args );
 			if ( ! empty( $params['url'] ) ) {
 				return $map->get_the_map_url();
 			}
@@ -152,10 +153,13 @@ class REST_Geo {
 	public static function lookup( $request ) {
 		$params       = $request->get_params();
 		$args['user'] = $params['user'];
-		$geolocation  = Loc_Config::default_geolocation_provider( $args );
-		if ( $geolocation ) {
+		$geolocation  = Loc_Config::geolocation_provider();
+		if ( is_object( $geolocation ) ) {
+			$gelocation->set( $args );
 			$geolocation->retrieve();
 			return $geolocation->get();
+		} elseif ( 'null' === $geolocation ) {
+			return $geolocation;
 		}
 		return new WP_Error( 'no_provider', __( 'No Geolocation Provider Available', 'simple-location' ), array( 'status' => 400 ) );
 	}
@@ -166,8 +170,8 @@ class REST_Geo {
 		// We don't need to specifically check the nonce like with admin-ajax. It is handled by the API.
 		$params = $request->get_params();
 		if ( ! empty( $params['longitude'] ) && ! empty( $params['latitude'] ) ) {
-			$reverse = Loc_Config::default_reverse_provider();
-			$reverse->set( $params['latitude'], $params['longitude'] );
+			$reverse = Loc_Config::geo_provider();
+			$reverse->set( $params );
 			$reverse_adr = $reverse->reverse_lookup();
 			if ( is_wp_error( $reverse_adr ) ) {
 				return $reverse_adr;
@@ -189,9 +193,9 @@ class REST_Geo {
 			$args['temp_units'] = $params['units'];
 		}
 		$return  = array();
-		$weather = Loc_Config::default_weather_provider( $args );
+		$weather = Loc_Config::weather_provider();
 		if ( ! empty( $params['longitude'] ) && ! empty( $params['latitude'] ) ) {
-			$weather->set_location( $params['latitude'], $params['longitude'] );
+			$weather->set( $params );
 			$return = array(
 				'latitude'  => $params['latitude'],
 				'longitude' => $params['longitude'],

--- a/includes/class-rest-geo.php
+++ b/includes/class-rest-geo.php
@@ -116,19 +116,6 @@ class REST_Geo {
 		);
 	}
 
-	/**
-	 * Returns if valid URL for REST validation
-	 *
-	 * @param string $url
-	 *
-	 * @return boolean
-	 */
-	public static function is_valid_url( $url, $request, $key ) {
-		if ( ! is_string( $url ) || empty( $url ) ) {
-			return false;
-		}
-		return filter_var( $url, FILTER_VALIDATE_URL );
-	}
 
 	// Callback Handler for Map Retrieval
 	public static function map( $request ) {

--- a/includes/class-sloc-provider.php
+++ b/includes/class-sloc-provider.php
@@ -1,15 +1,12 @@
 <?php
 
-abstract class Location_Provider extends Sloc_Provider {
+abstract class Sloc_Provider {
 
+	protected $slug;
+	protected $name;
 	protected $api;
-	protected $user;
 	protected $latitude;
 	protected $longitude;
-	protected $accuracy;
-	protected $altitude;
-	protected $heading;
-	protected $speed;
 
 	/**
 	 * Constructor for the Abstract Class
@@ -19,14 +16,30 @@ abstract class Location_Provider extends Sloc_Provider {
 	 * @param string $key API Key if Needed
 	 */
 	public function __construct( $args = array() ) {
-		$defaults   = array(
-			'api'  => null,
-			'user' => '',
+		$defaults  = array(
+			'api'       => null,
+			'latitude'  => null,
+			'longitude' => null,
 		);
-		$defaults   = apply_filters( 'sloc_location_provider_defaults', $defaults );
-		$r          = wp_parse_args( $args, $defaults );
-		$this->user = $r['user'];
-		$this->api  = $r['api'];
+		$r         = wp_parse_args( $args, $defaults );
+		$this->api = $r['api'];
+		$this->set( $r['latitude'], $r['longitude'] );
+	}
+
+	/**
+	 * Get Name
+	 *
+	 */
+	public function get_name() {
+		return $this->name;
+	}
+
+	/**
+	 * Get Slug
+	 *
+	 */
+	public function get_slug() {
+		return $this->slug;
 	}
 
 	/**
@@ -54,18 +67,10 @@ abstract class Location_Provider extends Sloc_Provider {
 		$return              = array();
 		$return['latitude']  = $this->latitude;
 		$return['longitude'] = $this->longitude;
-		$return['altitude']  = $this->altitude;
-		$return['accuracy']  = $this->accuracy;
-		$return['altitude']  = $this->altitude;
-		$return['heading']   = $this->heading;
-		$return['speed']     = $this->speed;
 		$return              = array_filter( $return );
 		if ( ! empty( $return ) ) {
 			return $return;
 		}
 		return false;
 	}
-
-
-	abstract public function retrieve();
 }

--- a/includes/class-sloc-provider.php
+++ b/includes/class-sloc-provider.php
@@ -45,17 +45,27 @@ abstract class Sloc_Provider {
 	/**
 	 * Set and Validate Coordinates
 	 *
-	 * @param $lat Latitude
+	 * @param $lat Latitude or array
 	 * @param $lng Longitude
 	 * @return boolean Return False if Validation Failed
 	 */
-	public function set( $lat, $lng ) {
+	public function set( $lat, $lng = null ) {
+		if ( ! $lng && is_array( $lat ) ) {
+			if ( isset( $lat['latitude'] ) && isset( $lat['longitude'] ) ) {
+				$this->latitude  = $lat['latitude'];
+				$this->longitude = $lat['longitude'];
+				return true;
+			} else {
+				return false;
+			}
+		}
 		// Validate inputs
 		if ( ( ! is_numeric( $lat ) ) && ( ! is_numeric( $lng ) ) ) {
 			return false;
 		}
 		$this->latitude  = $lat;
 		$this->longitude = $lng;
+		return true;
 	}
 
 	/**

--- a/includes/class-sloc-weather-widget.php
+++ b/includes/class-sloc-weather-widget.php
@@ -30,9 +30,9 @@ class Sloc_Weather_Widget extends WP_Widget {
 		$weather = new Weather_Provider_OpenWeatherMap();
 		if ( isset( $instance['user'] ) && 0 !== $instance['user'] ) {
 			$loc = WP_Geo_Data::get_geodata( new WP_User( $instance['user'] ) );
-			$weather->set_location( $loc['latitude'], $loc['longitude'] );
+			$weather->set( $loc['latitude'], $loc['longitude'] );
 		} elseif ( isset( $instance['latitude'] ) && isset( $instance['longitude'] ) ) {
-			$weather->set_location( $instance['latitude'], $instance['longitude'] );
+			$weather->set( $instance['latitude'], $instance['longitude'] );
 		}
 		echo $weather->get_current_condition(); // phpcs:ignore
 

--- a/includes/class-weather-provider-openweathermap.php
+++ b/includes/class-weather-provider-openweathermap.php
@@ -19,7 +19,6 @@ class Weather_Provider_OpenWeatherMap extends Weather_Provider {
 			$args['station_id'] = get_option( 'sloc_openweathermap_id' );
 		}
 		parent::__construct( $args );
-
 	}
 
 	/**
@@ -40,20 +39,21 @@ class Weather_Provider_OpenWeatherMap extends Weather_Provider {
 					return $conditions;
 				}
 			}
-			$url                  = 'https://api.openweathermap.org/data/2.5/weather?';
-			$data['lat']          = $this->latitude;
-			$data['lon']          = $this->longitude;
-			$url                  = $url . build_query( $data );
-							$args = array(
-								'headers'             => array(
-									'Accept' => 'application/json',
-								),
-								'timeout'             => 10,
-								'limit_response_size' => 1048576,
-								'redirection'         => 1,
-								// Use an explicit user-agent for Simple Location
-								'user-agent'          => 'Simple Location for WordPress',
-							);
+			$url           = 'https://api.openweathermap.org/data/2.5/weather?';
+			$data['lat']   = $this->latitude;
+			$data['lon']   = $this->longitude;
+			$url           = $url . build_query( $data );
+			$return['url'] = $url;
+			$args          = array(
+				'headers'             => array(
+					'Accept' => 'application/json',
+				),
+				'timeout'             => 10,
+				'limit_response_size' => 1048576,
+				'redirection'         => 1,
+				// Use an explicit user-agent for Simple Location
+				'user-agent'          => 'Simple Location for WordPress',
+			);
 
 			$response = wp_remote_get( $url, $args );
 			if ( is_wp_error( $response ) ) {

--- a/includes/class-weather-provider-openweathermap.php
+++ b/includes/class-weather-provider-openweathermap.php
@@ -10,6 +10,8 @@ class Weather_Provider_OpenWeatherMap extends Weather_Provider {
 	 * @param array $args
 	 */
 	public function __construct( $args = array() ) {
+		$this->name = __( 'OpenWeatherMap', 'simple-location' );
+		$this->slug = 'openweathermap';
 		if ( ! isset( $args['api'] ) ) {
 			$args['api'] = get_option( 'sloc_openweathermap_api' );
 		}
@@ -229,3 +231,5 @@ class Weather_Provider_OpenWeatherMap extends Weather_Provider {
 	}
 
 }
+
+register_sloc_provider( new Weather_Provider_OpenWeatherMap() );

--- a/includes/class-weather-provider-openweathermap.php
+++ b/includes/class-weather-provider-openweathermap.php
@@ -38,11 +38,22 @@ class Weather_Provider_OpenWeatherMap extends Weather_Provider {
 					return $conditions;
 				}
 			}
-			$url         = 'http://api.openweathermap.org/data/2.5/weather?';
-			$data['lat'] = $this->latitude;
-			$data['lon'] = $this->longitude;
-			$url         = $url . build_query( $data );
-			$response    = wp_remote_get( $url );
+			$url                  = 'https://api.openweathermap.org/data/2.5/weather?';
+			$data['lat']          = $this->latitude;
+			$data['lon']          = $this->longitude;
+			$url                  = $url . build_query( $data );
+							$args = array(
+								'headers'             => array(
+									'Accept' => 'application/json',
+								),
+								'timeout'             => 10,
+								'limit_response_size' => 1048576,
+								'redirection'         => 1,
+								// Use an explicit user-agent for Simple Location
+								'user-agent'          => 'Simple Location for WordPress',
+							);
+
+			$response = wp_remote_get( $url, $args );
 			if ( is_wp_error( $response ) ) {
 				return $response;
 			}

--- a/includes/class-weather-provider.php
+++ b/includes/class-weather-provider.php
@@ -23,7 +23,7 @@ abstract class Weather_Provider extends Sloc_Provider {
 			'station_id' => null,
 			'cache_key'  => 'slocw',
 			'cache_time' => 600,
-			'temp_units' => get_option( 'sloc_measurements' ),
+			'temp_units' => get_option( 'sloc_measurements', Loc_Config::temp_unit_default() ),
 			'style'      => '',
 		);
 		$defaults         = apply_filters( 'sloc_weather_provider_defaults', $defaults );

--- a/includes/class-weather-provider.php
+++ b/includes/class-weather-provider.php
@@ -1,11 +1,8 @@
 <?php
 
-abstract class Weather_Provider {
+abstract class Weather_Provider extends Sloc_Provider {
 
-	protected $api;
 	protected $style;
-	protected $latitude;
-	protected $longitude;
 	protected $station_id; // Most weather sites permit a station ID to be set
 	protected $temp_units; // Unit of measurement for temperature: imperial, metric, etc
 	protected $cache_key; // If set this will cache the retrieved informatin
@@ -37,7 +34,7 @@ abstract class Weather_Provider {
 		$this->temp_units = $r['temp_units'];
 		$this->cache_key  = $r['cache_key'];
 		$this->cache_time = $r['cache_time'];
-		$this->set_location( $r['latitude'], $r['longitude'] );
+		$this->set( $r['latitude'], $r['longitude'] );
 	}
 
 	public function get_station() {
@@ -52,22 +49,6 @@ abstract class Weather_Provider {
 		return ( $temp - 32 ) / 1.8;
 	}
 
-	/**
-	 * Set and Validate Coordinates
-	 *
-	 * @param $lat Latitude
-	 * @param $lng Longitude
-	 * @return boolean Return False if Validation Failed
-	 */
-	public function set_location( $lat, $lng ) {
-		// Validate inputs
-		if ( ( ! is_numeric( $lat ) ) && ( ! is_numeric( $lng ) ) ) {
-			return false;
-		}
-		$this->latitude  = $lat;
-		$this->longitude = $lng;
-	}
-
 	public function temp_unit() {
 		switch ( $this->temp_units ) {
 			case 'imperial':
@@ -76,24 +57,6 @@ abstract class Weather_Provider {
 				return 'C';
 		}
 	}
-
-
-	/**
-	 * Get Coordinates
-	 *
-	 * @return array|boolean Array with Latitude and Longitude false if null
-	 */
-	public function get_location() {
-		$return              = array();
-		$return['latitude']  = $this->latitude;
-		$return['longitude'] = $this->longitude;
-		$return              = array_filter( $return );
-		if ( ! empty( $return ) ) {
-			return $return;
-		}
-		return false;
-	}
-
 
 	/**
 	 * Return the marked up  icon standardized to the fontse

--- a/languages/simple-location.pot
+++ b/languages/simple-location.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Simple Location package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Simple Location 3.3.8\n"
+"Project-Id-Version: Simple Location 3.4.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/simple-location\n"
-"POT-Creation-Date: 2018-05-27 18:00:41+00:00\n"
+"POT-Creation-Date: 2018-10-23 03:23:01+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,205 +13,182 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 0.5.4\n"
 
-#: includes/class-geo-data.php:45
+#: includes/class-geo-data.php:63
 msgid "Private"
 msgstr ""
 
-#: includes/class-geo-data.php:46
+#: includes/class-geo-data.php:64
 msgid "Public"
 msgstr ""
 
-#: includes/class-geo-data.php:47
+#: includes/class-geo-data.php:65
 msgid "Protected"
 msgstr ""
 
-#: includes/class-geo-data.php:73
+#: includes/class-geo-data.php:91
 msgid "All Posts"
 msgstr ""
 
-#: includes/class-geo-data.php:74 includes/class-geo-data.php:91
+#: includes/class-geo-data.php:92 includes/class-geo-data.php:109
 msgid "With Location"
 msgstr ""
 
-#: includes/class-geo-data.php:90
+#: includes/class-geo-data.php:108
 msgid "All Comments"
 msgstr ""
 
-#: includes/class-geo-provider-bing.php:35
-msgid "Aerial Imagery"
+#: includes/class-geo-data.php:570 templates/loc-user-metabox.php:20
+#: templates/loc-user-metabox.php:24
+msgid "Latitude"
 msgstr ""
 
-#: includes/class-geo-provider-bing.php:36
-msgid "Aerial Imagery with a Road Overlay"
+#: includes/class-geo-data.php:581 templates/loc-user-metabox.php:27
+#: templates/loc-user-metabox.php:31
+msgid "Longitude"
 msgstr ""
 
-#: includes/class-geo-provider-bing.php:37
-msgid ""
-"A lighter version of the road maps which also has some of the details such "
-"as hill shading disabled."
+#: includes/class-geo-data.php:592 includes/class-loc-config.php:284
+#: includes/class-loc-metabox.php:103
+msgid "Location"
 msgstr ""
 
-#: includes/class-geo-provider-bing.php:38
-msgid "A dark version of the road maps."
+#: includes/class-geo-provider-bing.php:6
+msgid "Bing"
 msgstr ""
 
-#: includes/class-geo-provider-bing.php:39
-msgid "A grayscale version of the road maps."
+#: includes/class-geo-provider-google.php:6
+msgid "Google"
 msgstr ""
 
-#: includes/class-geo-provider-bing.php:40
-msgid "Roads without additional imagery"
-msgstr ""
-
-#: includes/class-geo-provider-google.php:35
-msgid "Roadmap"
-msgstr ""
-
-#: includes/class-geo-provider-google.php:36
-msgid "Satellite"
-msgstr ""
-
-#: includes/class-geo-provider-google.php:37
-msgid "Terrain"
-msgstr ""
-
-#: includes/class-geo-provider-google.php:38
-msgid "Satellite and Roadmap Hybrid"
+#: includes/class-geo-provider-nominatim.php:6
+msgid "Open Search(Nominatim) via Mapquest"
 msgstr ""
 
 #. Plugin Name of the plugin/theme
 msgid "Simple Location"
 msgstr ""
 
-#: includes/class-loc-config.php:223 includes/class-loc-metabox.php:102
-msgid "Location"
-msgstr ""
-
-#: includes/class-loc-config.php:244
+#: includes/class-loc-config.php:305
 msgid "API Keys and Settings for Simple Location"
 msgstr ""
 
-#: includes/class-loc-config.php:260
+#: includes/class-loc-config.php:321
 msgid "Map Settings"
 msgstr ""
 
-#: includes/class-loc-config.php:266
+#: includes/class-loc-config.php:327
 msgid "Map Provider"
 msgstr ""
 
-#: includes/class-loc-config.php:277
+#: includes/class-loc-config.php:338
 msgid "Reverse Provider"
 msgstr ""
 
-#: includes/class-loc-config.php:288
+#: includes/class-loc-config.php:349
 msgid "Geolocation Provider"
 msgstr ""
 
-#: includes/class-loc-config.php:299
+#: includes/class-loc-config.php:360
 msgid "Show Location By Default"
 msgstr ""
 
-#: includes/class-loc-config.php:309
+#: includes/class-loc-config.php:370
 msgid "Update Author Last Reported Location on New Post"
 msgstr ""
 
-#: includes/class-loc-config.php:319
+#: includes/class-loc-config.php:380
 msgid "Default Map Width"
 msgstr ""
 
-#: includes/class-loc-config.php:329
+#: includes/class-loc-config.php:390
 msgid "Default Map Height"
 msgstr ""
 
-#: includes/class-loc-config.php:339
+#: includes/class-loc-config.php:400
 msgid "Default Map Zoom"
 msgstr ""
 
-#: includes/class-loc-config.php:353
+#: includes/class-loc-config.php:415
+msgid "MapQuest API Key"
+msgstr ""
+
+#: includes/class-loc-config.php:426
+msgid "MapQuest Style"
+msgstr ""
+
+#: includes/class-loc-config.php:438
+msgid "HERE API Key"
+msgstr ""
+
+#: includes/class-loc-config.php:449
+msgid "HERE Application ID"
+msgstr ""
+
+#: includes/class-loc-config.php:461
 msgid "Google Maps API Key"
 msgstr ""
 
-#: includes/class-loc-config.php:364
+#: includes/class-loc-config.php:472
 msgid "Google Style"
 msgstr ""
 
-#: includes/class-loc-config.php:376
+#: includes/class-loc-config.php:484
 msgid "Bing API Key"
 msgstr ""
 
-#: includes/class-loc-config.php:388
+#: includes/class-loc-config.php:496
 msgid "Bing Style"
 msgstr ""
 
-#: includes/class-loc-config.php:400
+#: includes/class-loc-config.php:508
 msgid "Mapbox API Key"
 msgstr ""
 
-#: includes/class-loc-config.php:412
+#: includes/class-loc-config.php:520
 msgid "Mapbox User"
 msgstr ""
 
-#: includes/class-loc-config.php:424
+#: includes/class-loc-config.php:532
 msgid "Mapbox Style"
 msgstr ""
 
-#: includes/class-loc-config.php:437
+#: includes/class-loc-config.php:545
 msgid "Weather Settings"
 msgstr ""
 
-#: includes/class-loc-config.php:443
+#: includes/class-loc-config.php:551
 msgid "Unit of Measure"
 msgstr ""
 
-#: includes/class-loc-config.php:453
+#: includes/class-loc-config.php:561
 msgid "Weather Provider"
 msgstr ""
 
-#: includes/class-loc-config.php:464
+#: includes/class-loc-config.php:572
 msgid "OpenWeatherMap API Key"
 msgstr ""
 
-#: includes/class-loc-config.php:476
+#: includes/class-loc-config.php:584
 msgid "OpenWeatherMap Station ID"
 msgstr ""
 
-#: includes/class-loc-config.php:520
-msgid "OpenStreetMap/MapBox"
-msgstr ""
-
-#: includes/class-loc-config.php:521
-msgid "Google Maps"
-msgstr ""
-
-#: includes/class-loc-config.php:522
-msgid "Bing Maps"
-msgstr ""
-
-#: includes/class-loc-config.php:529
-msgid "OpenStreetMap/Nominatim"
-msgstr ""
-
-#: includes/class-loc-config.php:536
+#: includes/class-loc-config.php:648
 msgid "HTML5 Browser Geolocation (requires HTTPS)"
 msgstr ""
 
-#: includes/class-loc-config.php:544
-msgid "OpenWeatherMap"
-msgstr ""
-
-#: includes/class-loc-config.php:553
+#: includes/class-loc-config.php:668
 msgid "Metric"
 msgstr ""
 
-#: includes/class-loc-config.php:554
+#: includes/class-loc-config.php:669
 msgid "Imperial"
 msgstr ""
 
-#: includes/class-loc-config.php:577
+#: includes/class-loc-config.php:692
 msgid "API keys are required for map display services."
 msgstr ""
 
-#: includes/class-loc-config.php:581
+#: includes/class-loc-config.php:696
 msgid "API keys are required for most weather services."
 msgstr ""
 
@@ -223,7 +200,7 @@ msgstr ""
 msgid "Location:"
 msgstr ""
 
-#: includes/class-loc-metabox.php:113
+#: includes/class-loc-metabox.php:114
 msgid "Show:"
 msgstr ""
 
@@ -231,15 +208,94 @@ msgstr ""
 msgid "Location: "
 msgstr ""
 
-#: includes/class-post-timezone.php:58
-msgid "Set Local Timezone"
+#: includes/class-map-provider-bing.php:7
+msgid "Bing Maps"
+msgstr ""
+
+#: includes/class-map-provider-bing.php:20
+msgid "Aerial Imagery"
+msgstr ""
+
+#: includes/class-map-provider-bing.php:21
+msgid "Aerial Imagery with a Road Overlay"
+msgstr ""
+
+#: includes/class-map-provider-bing.php:22
+msgid ""
+"A lighter version of the road maps which also has some of the details such "
+"as hill shading disabled."
+msgstr ""
+
+#: includes/class-map-provider-bing.php:23
+msgid "A dark version of the road maps."
+msgstr ""
+
+#: includes/class-map-provider-bing.php:24
+msgid "A grayscale version of the road maps."
+msgstr ""
+
+#: includes/class-map-provider-bing.php:25
+msgid "Roads without additional imagery"
+msgstr ""
+
+#: includes/class-map-provider-google.php:7
+msgid "Google Maps"
+msgstr ""
+
+#: includes/class-map-provider-google.php:20
+msgid "Roadmap"
+msgstr ""
+
+#: includes/class-map-provider-google.php:21
+#: includes/class-map-provider-mapquest.php:22
+msgid "Satellite"
+msgstr ""
+
+#: includes/class-map-provider-google.php:22
+msgid "Terrain"
+msgstr ""
+
+#: includes/class-map-provider-google.php:23
+msgid "Satellite and Roadmap Hybrid"
+msgstr ""
+
+#: includes/class-map-provider-here.php:7
+msgid "HERE Maps"
+msgstr ""
+
+#: includes/class-map-provider-mapbox.php:6
+msgid "Mapbox"
+msgstr ""
+
+#: includes/class-map-provider-mapquest.php:7
+msgid "Mapquest Maps"
+msgstr ""
+
+#: includes/class-map-provider-mapquest.php:20
+msgid "Basic Map"
+msgstr ""
+
+#: includes/class-map-provider-mapquest.php:21
+msgid "Hybrid"
+msgstr ""
+
+#: includes/class-map-provider-mapquest.php:23
+msgid "Light"
+msgstr ""
+
+#: includes/class-map-provider-mapquest.php:24
+msgid "Dark"
 msgstr ""
 
 #: includes/class-post-timezone.php:59
+msgid "Set Local Timezone"
+msgstr ""
+
+#: includes/class-post-timezone.php:60
 msgid "Timezone:"
 msgstr ""
 
-#: includes/class-rest-geo.php:152 includes/class-rest-geo.php:181
+#: includes/class-rest-geo.php:149 includes/class-rest-geo.php:181
 msgid "Missing Coordinates for Reverse Lookup"
 msgstr ""
 
@@ -259,22 +315,22 @@ msgstr ""
 msgid "Displays Last Seen"
 msgstr ""
 
-#: includes/class-sloc-lastseen-widget.php:31
+#: includes/class-sloc-lastseen-widget.php:32
 msgid "Last Seen: "
 msgstr ""
 
-#: includes/class-sloc-lastseen-widget.php:63
+#: includes/class-sloc-lastseen-widget.php:66
 msgid "Displays last reported user location"
 msgstr ""
 
-#: includes/class-sloc-lastseen-widget.php:65
+#: includes/class-sloc-lastseen-widget.php:68
 #: includes/class-sloc-weather-widget.php:65
 msgid "User: "
 msgstr ""
 
-#: includes/class-sloc-lastseen-widget.php:71
+#: includes/class-sloc-lastseen-widget.php:74
 #: includes/class-sloc-weather-widget.php:71
-#: includes/class-weather-provider.php:303
+#: includes/class-weather-provider.php:267
 msgid "None"
 msgstr ""
 
@@ -301,630 +357,634 @@ msgstr ""
 msgid "Longitude: "
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:49 includes/class-venue-taxonomy.php:63
+#: includes/class-venue-taxonomy.php:50 includes/class-venue-taxonomy.php:64
 msgid "Venues"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:50
+#: includes/class-venue-taxonomy.php:51
 msgid "Venue"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:51
+#: includes/class-venue-taxonomy.php:52
 msgid "Search Venues"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:52
+#: includes/class-venue-taxonomy.php:53
 msgid "Popular Venues"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:53
+#: includes/class-venue-taxonomy.php:54
 msgid "All Venues"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:54
+#: includes/class-venue-taxonomy.php:55
 msgid "Parent Vanue"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:55
+#: includes/class-venue-taxonomy.php:56
 msgid "Parent Venue:"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:56
+#: includes/class-venue-taxonomy.php:57
 msgid "Edit Venue"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:57
+#: includes/class-venue-taxonomy.php:58
 msgid "Update Venue"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:58
+#: includes/class-venue-taxonomy.php:59
 msgid "Add New Venue"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:59
+#: includes/class-venue-taxonomy.php:60
 msgid "New Venue"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:60
+#: includes/class-venue-taxonomy.php:61
 msgid "Separate venues with commas"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:61
+#: includes/class-venue-taxonomy.php:62
 msgid "Add or remove venues"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:62
+#: includes/class-venue-taxonomy.php:63
 msgid "Choose from the most used venues"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:68
+#: includes/class-venue-taxonomy.php:69
 msgid "Reflects a location"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:94 includes/class-venue-taxonomy.php:108
+#: includes/class-venue-taxonomy.php:95 includes/class-venue-taxonomy.php:109
 #: templates/loc-metabox.php:38
 msgid "Latitude:"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:96 includes/class-venue-taxonomy.php:111
+#: includes/class-venue-taxonomy.php:97 includes/class-venue-taxonomy.php:112
 #: templates/loc-metabox.php:43
 msgid "Longitude:"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:99 includes/class-venue-taxonomy.php:115
+#: includes/class-venue-taxonomy.php:100 includes/class-venue-taxonomy.php:116
 msgid "Get Location"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:117 templates/loc-metabox.php:86
+#: includes/class-venue-taxonomy.php:118 templates/loc-metabox.php:86
 #: templates/loc-user-metabox.php:34 templates/loc-user-metabox.php:38
 msgid "Address"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:120 templates/loc-metabox.php:95
+#: includes/class-venue-taxonomy.php:121 templates/loc-metabox.php:95
 msgid "City/Town/Village"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:123 templates/loc-metabox.php:106
+#: includes/class-venue-taxonomy.php:124 templates/loc-metabox.php:106
 msgid "State/County/Province"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:126 templates/loc-metabox.php:120
+#: includes/class-venue-taxonomy.php:127 templates/loc-metabox.php:120
 msgid "Country Code"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:129 templates/loc-metabox.php:100
+#: includes/class-venue-taxonomy.php:130 templates/loc-metabox.php:100
 msgid "Neighborhood/Suburb"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:131 templates/loc-metabox.php:111
+#: includes/class-venue-taxonomy.php:132 templates/loc-metabox.php:111
 msgid "Postal Code"
 msgstr ""
 
-#: includes/class-venue-taxonomy.php:134 templates/loc-metabox.php:116
+#: includes/class-venue-taxonomy.php:135 templates/loc-metabox.php:116
 msgid "Country Name"
 msgstr ""
 
-#: includes/class-weather-provider.php:154
+#: includes/class-weather-provider-openweathermap.php:13
+msgid "OpenWeatherMap"
+msgstr ""
+
+#: includes/class-weather-provider.php:118
 msgid "Cloud"
 msgstr ""
 
-#: includes/class-weather-provider.php:155
+#: includes/class-weather-provider.php:119
 msgid "Cloudy"
 msgstr ""
 
-#: includes/class-weather-provider.php:156
+#: includes/class-weather-provider.php:120
 msgid "Cloudy with Gusts"
 msgstr ""
 
-#: includes/class-weather-provider.php:157
+#: includes/class-weather-provider.php:121
 msgid "Cloudy with Wind"
 msgstr ""
 
-#: includes/class-weather-provider.php:158
+#: includes/class-weather-provider.php:122
 msgid "Showers"
 msgstr ""
 
-#: includes/class-weather-provider.php:159
+#: includes/class-weather-provider.php:123
 msgid "Rain-Mix"
 msgstr ""
 
-#: includes/class-weather-provider.php:160
+#: includes/class-weather-provider.php:124
 msgid "Rain"
 msgstr ""
 
-#: includes/class-weather-provider.php:161
+#: includes/class-weather-provider.php:125
 msgid "Rain and Windy"
 msgstr ""
 
-#: includes/class-weather-provider.php:162
+#: includes/class-weather-provider.php:126
 msgid "Snow"
 msgstr ""
 
-#: includes/class-weather-provider.php:163
+#: includes/class-weather-provider.php:127
 msgid "Snow and Wind"
 msgstr ""
 
-#: includes/class-weather-provider.php:164
+#: includes/class-weather-provider.php:128
 msgid "Fog"
 msgstr ""
 
-#: includes/class-weather-provider.php:165
+#: includes/class-weather-provider.php:129
 msgid "Hot"
 msgstr ""
 
-#: includes/class-weather-provider.php:166
+#: includes/class-weather-provider.php:130
 msgid "Lightning"
 msgstr ""
 
-#: includes/class-weather-provider.php:167
+#: includes/class-weather-provider.php:131
 msgid "Sandstorm"
 msgstr ""
 
-#: includes/class-weather-provider.php:168
+#: includes/class-weather-provider.php:132
 msgid "Sleet"
 msgstr ""
 
-#: includes/class-weather-provider.php:169
+#: includes/class-weather-provider.php:133
 msgid "Smog"
 msgstr ""
 
-#: includes/class-weather-provider.php:170
+#: includes/class-weather-provider.php:134
 msgid "Smoke"
 msgstr ""
 
-#: includes/class-weather-provider.php:171
+#: includes/class-weather-provider.php:135
 msgid "Snowflake-Cold"
 msgstr ""
 
-#: includes/class-weather-provider.php:172
+#: includes/class-weather-provider.php:136
 msgid "Solar Eclipse"
 msgstr ""
 
-#: includes/class-weather-provider.php:173
+#: includes/class-weather-provider.php:137
 msgid "Sprinkles"
 msgstr ""
 
-#: includes/class-weather-provider.php:174
+#: includes/class-weather-provider.php:138
 msgid "Stars"
 msgstr ""
 
-#: includes/class-weather-provider.php:175
+#: includes/class-weather-provider.php:139
 msgid "Storm Showers"
 msgstr ""
 
-#: includes/class-weather-provider.php:176
+#: includes/class-weather-provider.php:140
 msgid "Storm Warning"
 msgstr ""
 
-#: includes/class-weather-provider.php:177
+#: includes/class-weather-provider.php:141
 msgid "Strong Winds"
 msgstr ""
 
-#: includes/class-weather-provider.php:178
+#: includes/class-weather-provider.php:142
 msgid "Thunderstorm"
 msgstr ""
 
-#: includes/class-weather-provider.php:179
+#: includes/class-weather-provider.php:143
 msgid "Windy"
 msgstr ""
 
-#: includes/class-weather-provider.php:180
+#: includes/class-weather-provider.php:144
 msgid "Gale Warning"
 msgstr ""
 
-#: includes/class-weather-provider.php:181
+#: includes/class-weather-provider.php:145
 msgid "Hail"
 msgstr ""
 
-#: includes/class-weather-provider.php:182
+#: includes/class-weather-provider.php:146
 msgid "Hurricane"
 msgstr ""
 
-#: includes/class-weather-provider.php:183
+#: includes/class-weather-provider.php:147
 msgid "Hurricane Warning"
 msgstr ""
 
-#: includes/class-weather-provider.php:184
+#: includes/class-weather-provider.php:148
 msgid "Dust"
 msgstr ""
 
-#: includes/class-weather-provider.php:185
+#: includes/class-weather-provider.php:149
 msgid "Earthquake"
 msgstr ""
 
-#: includes/class-weather-provider.php:186
+#: includes/class-weather-provider.php:150
 msgid "Fire"
 msgstr ""
 
-#: includes/class-weather-provider.php:187
+#: includes/class-weather-provider.php:151
 msgid "Flood"
 msgstr ""
 
-#: includes/class-weather-provider.php:191
+#: includes/class-weather-provider.php:155
 msgid "Sunny"
 msgstr ""
 
-#: includes/class-weather-provider.php:192
+#: includes/class-weather-provider.php:156
 msgid "Sunny and Overcast"
 msgstr ""
 
-#: includes/class-weather-provider.php:193
+#: includes/class-weather-provider.php:157
 msgid "Cloudy - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:194
+#: includes/class-weather-provider.php:158
 msgid "Cloudy with Gusts - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:195
+#: includes/class-weather-provider.php:159
 msgid "Cloudy High Winds - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:196
+#: includes/class-weather-provider.php:160
 msgid "Cloudy and Windy - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:197
+#: includes/class-weather-provider.php:161
 msgid "Fog - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:198
+#: includes/class-weather-provider.php:162
 msgid "Hail - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:199
+#: includes/class-weather-provider.php:163
 msgid "Haze - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:200
+#: includes/class-weather-provider.php:164
 msgid "Lightning - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:201
+#: includes/class-weather-provider.php:165
 msgid "Lighting and Wind - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:202
+#: includes/class-weather-provider.php:166
 msgid "Rainy Mix - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:203
+#: includes/class-weather-provider.php:167
 msgid "Rain - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:204
+#: includes/class-weather-provider.php:168
 msgid "Rain and Wind - Daytime"
 msgstr ""
 
-#: includes/class-weather-provider.php:205
+#: includes/class-weather-provider.php:169
 msgid "Showers - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:206
+#: includes/class-weather-provider.php:170
 msgid "Sleet Storm - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:207
+#: includes/class-weather-provider.php:171
 msgid "Sleet - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:208
+#: includes/class-weather-provider.php:172
 msgid "Snow - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:209
+#: includes/class-weather-provider.php:173
 msgid "Snow and Thunderstorms - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:210
+#: includes/class-weather-provider.php:174
 msgid "Snow and Wind - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:211
+#: includes/class-weather-provider.php:175
 msgid "Sprinkles - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:212
+#: includes/class-weather-provider.php:176
 msgid "Storm Showers - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:213
+#: includes/class-weather-provider.php:177
 msgid "Thunderstorm - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:214
+#: includes/class-weather-provider.php:178
 msgid "Windy - Day"
 msgstr ""
 
-#: includes/class-weather-provider.php:217
+#: includes/class-weather-provider.php:181
 msgid "Clear Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:218
+#: includes/class-weather-provider.php:182
 msgid "Cloudy - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:219
+#: includes/class-weather-provider.php:183
 msgid "Cloudy with Gusts - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:220
+#: includes/class-weather-provider.php:184
 msgid "Cloudy with High Winds - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:221
+#: includes/class-weather-provider.php:185
 msgid "Cloudy and Windy - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:222
+#: includes/class-weather-provider.php:186
 msgid "Fog - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:223
+#: includes/class-weather-provider.php:187
 msgid "Hail - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:224
+#: includes/class-weather-provider.php:188
 msgid "Lightning - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:225
+#: includes/class-weather-provider.php:189
 msgid "Partly Cloudy - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:226
+#: includes/class-weather-provider.php:190
 msgid "Rainy Mix - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:227
+#: includes/class-weather-provider.php:191
 msgid "Rain - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:228
+#: includes/class-weather-provider.php:192
 msgid "Rain and Wind - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:229
+#: includes/class-weather-provider.php:193
 msgid "Showers - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:230
+#: includes/class-weather-provider.php:194
 msgid "Sleet Storm - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:231
+#: includes/class-weather-provider.php:195
 msgid "Sleet - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:232
+#: includes/class-weather-provider.php:196
 msgid "Snow - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:233
+#: includes/class-weather-provider.php:197
 msgid "Snow and Thunderstorm - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:234
+#: includes/class-weather-provider.php:198
 msgid "Snow and Wind - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:235
+#: includes/class-weather-provider.php:199
 msgid "Sprinkles - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:236
+#: includes/class-weather-provider.php:200
 msgid "Storm Showers - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:237
+#: includes/class-weather-provider.php:201
 msgid "Thunderstorms - Night"
 msgstr ""
 
-#: includes/class-weather-provider.php:238
+#: includes/class-weather-provider.php:202
 msgid "Lunar Eclipse"
 msgstr ""
 
-#: includes/class-weather-provider.php:241
+#: includes/class-weather-provider.php:205
 msgid "Barometer"
 msgstr ""
 
-#: includes/class-weather-provider.php:242
+#: includes/class-weather-provider.php:206
 msgid "Thermometer"
 msgstr ""
 
-#: includes/class-weather-provider.php:243
+#: includes/class-weather-provider.php:207
 msgid "Thermometer - Exterior"
 msgstr ""
 
-#: includes/class-weather-provider.php:244
+#: includes/class-weather-provider.php:208
 msgid "Thermometer - Internal"
 msgstr ""
 
-#: includes/class-weather-provider.php:245
+#: includes/class-weather-provider.php:209
 msgid "Celsius"
 msgstr ""
 
-#: includes/class-weather-provider.php:246
+#: includes/class-weather-provider.php:210
 msgid "Fahrenheit"
 msgstr ""
 
-#: includes/class-weather-provider.php:247
+#: includes/class-weather-provider.php:211
 msgid "Humidity"
 msgstr ""
 
-#: includes/class-weather-provider.php:248
+#: includes/class-weather-provider.php:212
 msgid "Degrees"
 msgstr ""
 
-#: includes/class-weather-provider.php:249
+#: includes/class-weather-provider.php:213
 msgid "Raindrops"
 msgstr ""
 
-#: includes/class-weather-provider.php:250
+#: includes/class-weather-provider.php:214
 msgid "Raindrop"
 msgstr ""
 
-#: includes/class-weather-provider.php:251
+#: includes/class-weather-provider.php:215
 msgid "Horizon"
 msgstr ""
 
-#: includes/class-weather-provider.php:252
+#: includes/class-weather-provider.php:216
 msgid "N/A"
 msgstr ""
 
-#: includes/class-weather-provider.php:253
+#: includes/class-weather-provider.php:217
 msgid "Sunrise"
 msgstr ""
 
-#: includes/class-weather-provider.php:254
+#: includes/class-weather-provider.php:218
 msgid "Sunset"
 msgstr ""
 
-#: includes/class-weather-provider.php:255
+#: includes/class-weather-provider.php:219
 msgid "Umbrella"
 msgstr ""
 
-#: includes/class-weather-provider.php:256
+#: includes/class-weather-provider.php:220
 msgid "Meteor"
 msgstr ""
 
-#: includes/class-weather-provider.php:257
+#: includes/class-weather-provider.php:221
 msgid "Tornado"
 msgstr ""
 
-#: includes/class-weather-provider.php:258
+#: includes/class-weather-provider.php:222
 msgid "Tsunami"
 msgstr ""
 
-#: includes/class-weather-provider.php:259
+#: includes/class-weather-provider.php:223
 msgid "Volcano"
 msgstr ""
 
-#: includes/class-weather-provider.php:263
+#: includes/class-weather-provider.php:227
 msgid "First Quarter Moon"
 msgstr ""
 
-#: includes/class-weather-provider.php:264
+#: includes/class-weather-provider.php:228
 msgid "Full Moon"
 msgstr ""
 
-#: includes/class-weather-provider.php:265
+#: includes/class-weather-provider.php:229
 msgid "New Moon"
 msgstr ""
 
-#: includes/class-weather-provider.php:266
+#: includes/class-weather-provider.php:230
 msgid "Moonrise"
 msgstr ""
 
-#: includes/class-weather-provider.php:267
+#: includes/class-weather-provider.php:231
 msgid "Moonset"
 msgstr ""
 
-#: includes/class-weather-provider.php:268
+#: includes/class-weather-provider.php:232
 msgid "Third Quarter Moon"
 msgstr ""
 
-#: includes/class-weather-provider.php:269
+#: includes/class-weather-provider.php:233
 msgid "Waning Crescent 1"
 msgstr ""
 
-#: includes/class-weather-provider.php:270
+#: includes/class-weather-provider.php:234
 msgid "Waning Crescent 2"
 msgstr ""
 
-#: includes/class-weather-provider.php:271
+#: includes/class-weather-provider.php:235
 msgid "Waning Crescent 3"
 msgstr ""
 
-#: includes/class-weather-provider.php:272
+#: includes/class-weather-provider.php:236
 msgid "Waning Crescent 4"
 msgstr ""
 
-#: includes/class-weather-provider.php:273
+#: includes/class-weather-provider.php:237
 msgid "Waning Crescent 5"
 msgstr ""
 
-#: includes/class-weather-provider.php:274
+#: includes/class-weather-provider.php:238
 msgid "Waning Crescent 6"
 msgstr ""
 
-#: includes/class-weather-provider.php:275
+#: includes/class-weather-provider.php:239
 msgid "Waning Gibbous 1"
 msgstr ""
 
-#: includes/class-weather-provider.php:276
+#: includes/class-weather-provider.php:240
 msgid "Waning Gibbous 2"
 msgstr ""
 
-#: includes/class-weather-provider.php:277
+#: includes/class-weather-provider.php:241
 msgid "Waning Gibbous 3"
 msgstr ""
 
-#: includes/class-weather-provider.php:278
+#: includes/class-weather-provider.php:242
 msgid "Waning Gibbous 4"
 msgstr ""
 
-#: includes/class-weather-provider.php:279
+#: includes/class-weather-provider.php:243
 msgid "Waning Gibbous 5"
 msgstr ""
 
-#: includes/class-weather-provider.php:280
+#: includes/class-weather-provider.php:244
 msgid "Waning Gibbous 6"
 msgstr ""
 
-#: includes/class-weather-provider.php:281
+#: includes/class-weather-provider.php:245
 msgid "Waxing Crescent 1"
 msgstr ""
 
-#: includes/class-weather-provider.php:282
+#: includes/class-weather-provider.php:246
 msgid "Waxing Crescent 2"
 msgstr ""
 
-#: includes/class-weather-provider.php:283
+#: includes/class-weather-provider.php:247
 msgid "Waxing Crescent 3"
 msgstr ""
 
-#: includes/class-weather-provider.php:284
+#: includes/class-weather-provider.php:248
 msgid "Waxing Crescent 4"
 msgstr ""
 
-#: includes/class-weather-provider.php:285
+#: includes/class-weather-provider.php:249
 msgid "Waxing Crescent 5"
 msgstr ""
 
-#: includes/class-weather-provider.php:286
+#: includes/class-weather-provider.php:250
 msgid "Waxing Crescent 6"
 msgstr ""
 
-#: includes/class-weather-provider.php:287
+#: includes/class-weather-provider.php:251
 msgid "Waxing Gibbous 1"
 msgstr ""
 
-#: includes/class-weather-provider.php:288
+#: includes/class-weather-provider.php:252
 msgid "Waxing Gibbous 2"
 msgstr ""
 
-#: includes/class-weather-provider.php:289
+#: includes/class-weather-provider.php:253
 msgid "Waxing Gibbous 3"
 msgstr ""
 
-#: includes/class-weather-provider.php:290
+#: includes/class-weather-provider.php:254
 msgid "Waxing Gibbous 4"
 msgstr ""
 
-#: includes/class-weather-provider.php:291
+#: includes/class-weather-provider.php:255
 msgid "Waxing Gibbous 5"
 msgstr ""
 
-#: includes/class-weather-provider.php:292
+#: includes/class-weather-provider.php:256
 msgid "Waxing Gibbous 6"
 msgstr ""
 
-#: simple-location.php:105
+#: simple-location.php:110
 msgid "Settings"
 msgstr ""
 
-#: simple-location.php:119
+#: simple-location.php:124
 msgid ""
 "Location and weather data is optionally stored for all posts, attachments, "
 "and comments. Location data is extracted from uploaded images along with "
@@ -1022,14 +1082,6 @@ msgstr ""
 
 #: templates/loc-user-metabox.php:13
 msgid "Use My Current Location"
-msgstr ""
-
-#: templates/loc-user-metabox.php:20 templates/loc-user-metabox.php:24
-msgid "Latitude"
-msgstr ""
-
-#: templates/loc-user-metabox.php:27 templates/loc-user-metabox.php:31
-msgid "Longitude"
 msgstr ""
 
 #. Plugin URI of the plugin/theme

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 # Simple Location #
 **Contributors:** [dshanske](https://profiles.wordpress.org/dshanske)  
 **Tags:** geolocation, geo, maps, location, weather, indieweb  
-**Stable tag:** 3.3.8  
+**Stable tag:** 3.4.0  
 **Requires at least:** 4.7  
-**Tested up to:** 4.9.6  
+**Tested up to:** 4.9.8  
 **Requires PHP:** 5.3  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -41,10 +41,12 @@ To add anything more than a basic location you will have to create a venue. This
 
 ## WordPress GeoData ##
 
-[WordPress Geodata](http://codex.wordpress.org/Geodata) is an existing standard
-used to store geodata about a post, user, comment, or term.
+[WordPress Geodata](http://codex.wordpress.org/Geodata) is an existing standardized way to store geodata about a post, user, comment, or term.
 
-It consists of four fields: latitude, longitude, public, and address. This matches up with the HTML5 Geolocation fields. The plugin also saves zoom which is for the purpose of map display.
+It consists of four fields: latitude, longitude, public, and address. This matches up with the HTML5 Geolocation fields. The [W3C Geolocation Specification](https://dev.w3.org/geo/api/spec-source.html) 
+also provides for properties of altitude, accuracy, altitudeAccuracy, speed, and heading, which may be stored. Map Zoom is also stored as a geodata property.
+
+Timezone is also stored as a property and is derived from the location.
 
 ## Weather ##
 
@@ -52,6 +54,16 @@ Weather consists of at minimum the current conditions and temperature but may in
 is available that can be set to a specific location, a user, or a station ID.
 
 Station ID is available from supported providers for weather stations, for example from a Personal Weather Station(PWS).
+
+## Providers ##
+
+The plugin is designed to be extensible and anyone could write a plugin that would add additional providers.
+
+* Map Providers include MapBox, Google, Mapquest's Open Static Map, and Bing
+* Geocoding Providers include the Mapquest hosted version of Nominatim and Google.
+* Location Providers only offer HTML5 Browser Geolocation
+* Weather Providers only include OpenWeatherMap
+
 
 ## Frequently Asked Questions ##
 
@@ -62,13 +74,19 @@ API Keys are required to use certain services.
 * [Mapbox Static Maps](https://www.mapbox.com/help/create-api-access-token/)
 * [Bing Maps](https://www.bingmapsportal.com/)
 * [OpenWeatherMap](http://openweathermap.com/api)
+* [MapQuest](https://developer.mapquest.com/)
+* [HERE](https://developer.here.com/)
 
-If not provided there will be no map displayed regardless of setting. Without a weather provider this service will not work. The appropriate API keys should be entered in Settings->Simple Location or will move to Indieweb->Location if the Indieweb plugin
-if installed.
+If not provided there will be no map displayed regardless of setting and reverse geo lookup will not work 
+Without a weather provider this service will not work. 
+
+The appropriate API keys should be entered in Settings->Simple Location or will move to Indieweb->Location if the Indieweb plugin if installed.
 
 ### Is this compatible with the WordPress mobile apps? ###
 
-Simple Location uses WordPress Geodata to store location, as does the WordPress app. So setting location with the app should allow it to be displayed by Simple Location.
+Simple Location uses WordPress Geodata to store location, as does the WordPress app. So setting location with the app should allow it to be displayed by Simple Location. The only major difference
+is that whether or not a location is public is set with either 0 for private or 1 for public. The spec implemented states a non-zero number is considered public. This plugin adds the option of 2,
+also known as protected, which shows a textual description of the location but does not display a map or geographic coordinates.
 
 ### The Location Icon does not retrieve my location. ###
 
@@ -79,16 +97,54 @@ data.
 
 You can filter any query or archive by adding `?geo={all|public|text}` to it to show only public posts with location. Adding /geo/all to the homepage or archive pages should also work
 
+### JetPack offers Location Display, why do I need this? ###
+
+JetPack only began offering location display in 2017, 3 years after this plugin was created. This plugin disables their implementation as it created conflicts.
+
+They do not offer the features this plugin does and their goal is a minimal implementation.
+
+
 ### How can I report issues or request support? ###
 
 The Development Version as well as support can be found on [Github](https://github.com/dshanske/simple-location).
 
+### How can I add support for ___ ? ###
+
+Simple Location has the concept of Providers. Providers are an abstract class that you can implement to take information from one format into the one Simple Location understands.
+The plugin offers providers for:
+* Geolocation - Looking up an address from coordinates or vice versa
+* Location - By default this uses your browser to lookup your location but you can alternatively tap into a service to get your current location, perhaps from your phone
+* Weather - Retrieves weather based on location or station ID
+* Map - Provides maps for display
+
 ## Upgrade Notice ##
+
+### 3.4.0 ###
+
+Hardcoded and filtered options for new providers have been replaced by a provider registration function with the strings and slug for the provider set inside the provider itself.
+
+### 3.0.0 ###
 
 Recommend backup before upgrade to Version 3.0.0 due to the start of venue support. Full location data will not be saved in the post and old posts will be converted. The display name will be saved if set, otherwise a display name will be set from the coordinates. An API key
 will now be required to show maps for services that require API keys.
 
 ## Changelog ##
+
+### 3.4.0 ( 2018-xx-xx ) ###
+* Fix for incorrect return when there is an error
+* Nominatim began to block reverse traffic so added additional options for reverse lookup.
+* Map Providers and Geo Providers are now separated
+* Unload Jetpack Geo Location which was added unknown to me in 2017. However added compatibility functions to ensure functionality matches
+* Declares post-type support for geo-location which is something the JetPack plugin does
+* Adds location meta tags
+* Add sanitize function that ensures geo_public is always saved as an integer
+* Empty address now causes plugin to display coordinates if not private
+* Provider registration now done by function as opposed to filter
+* Mapquests hosted version of Nominatim now offered but requires API Key
+* Mapquest Static Maps now a supported map provider
+* HERE Maps is now a supported map provider
+* Google is now a supported reverse lookup provider
+* Bing is now a supported reverse lookup provider
 
 ### 3.3.8 ( 2018-05-27 ) ###
 * Fix for jsonFeed error

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Simple Location ===
 Contributors: dshanske
 Tags: geolocation, geo, maps, location, weather, indieweb
-Stable tag: 3.3.8
+Stable tag: 3.4.0
 Requires at least: 4.7
-Tested up to: 4.9.6
+Tested up to: 4.9.8
 Requires PHP: 5.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -41,10 +41,12 @@ To add anything more than a basic location you will have to create a venue. This
 
 == WordPress GeoData ==
 
-[WordPress Geodata](http://codex.wordpress.org/Geodata) is an existing standard
-used to store geodata about a post, user, comment, or term.
+[WordPress Geodata](http://codex.wordpress.org/Geodata) is an existing standardized way to store geodata about a post, user, comment, or term.
 
-It consists of four fields: latitude, longitude, public, and address. This matches up with the HTML5 Geolocation fields. The plugin also saves zoom which is for the purpose of map display.
+It consists of four fields: latitude, longitude, public, and address. This matches up with the HTML5 Geolocation fields. The [W3C Geolocation Specification](https://dev.w3.org/geo/api/spec-source.html) 
+also provides for properties of altitude, accuracy, altitudeAccuracy, speed, and heading, which may be stored. Map Zoom is also stored as a geodata property.
+
+Timezone is also stored as a property and is derived from the location.
 
 == Weather ==
 
@@ -52,6 +54,16 @@ Weather consists of at minimum the current conditions and temperature but may in
 is available that can be set to a specific location, a user, or a station ID.
 
 Station ID is available from supported providers for weather stations, for example from a Personal Weather Station(PWS).
+
+== Providers ==
+
+The plugin is designed to be extensible and anyone could write a plugin that would add additional providers.
+
+* Map Providers include MapBox, Google, Mapquest's Open Static Map, and Bing
+* Geocoding Providers include the Mapquest hosted version of Nominatim and Google.
+* Location Providers only offer HTML5 Browser Geolocation
+* Weather Providers only include OpenWeatherMap
+
 
 == Frequently Asked Questions ==
 
@@ -62,13 +74,19 @@ API Keys are required to use certain services.
 * [Mapbox Static Maps](https://www.mapbox.com/help/create-api-access-token/)
 * [Bing Maps](https://www.bingmapsportal.com/)
 * [OpenWeatherMap](http://openweathermap.com/api)
+* [MapQuest](https://developer.mapquest.com/)
+* [HERE](https://developer.here.com/)
 
-If not provided there will be no map displayed regardless of setting. Without a weather provider this service will not work. The appropriate API keys should be entered in Settings->Simple Location or will move to Indieweb->Location if the Indieweb plugin
-if installed.
+If not provided there will be no map displayed regardless of setting and reverse geo lookup will not work 
+Without a weather provider this service will not work. 
+
+The appropriate API keys should be entered in Settings->Simple Location or will move to Indieweb->Location if the Indieweb plugin if installed.
 
 = Is this compatible with the WordPress mobile apps? =
 
-Simple Location uses WordPress Geodata to store location, as does the WordPress app. So setting location with the app should allow it to be displayed by Simple Location.
+Simple Location uses WordPress Geodata to store location, as does the WordPress app. So setting location with the app should allow it to be displayed by Simple Location. The only major difference
+is that whether or not a location is public is set with either 0 for private or 1 for public. The spec implemented states a non-zero number is considered public. This plugin adds the option of 2,
+also known as protected, which shows a textual description of the location but does not display a map or geographic coordinates.
 
 = The Location Icon does not retrieve my location. =
 
@@ -79,16 +97,54 @@ data.
 
 You can filter any query or archive by adding `?geo={all|public|text}` to it to show only public posts with location. Adding /geo/all to the homepage or archive pages should also work
 
+= JetPack offers Location Display, why do I need this? =
+
+JetPack only began offering location display in 2017, 3 years after this plugin was created. This plugin disables their implementation as it created conflicts.
+
+They do not offer the features this plugin does and their goal is a minimal implementation.
+
+
 = How can I report issues or request support? =
 
 The Development Version as well as support can be found on [Github](https://github.com/dshanske/simple-location).
 
+= How can I add support for ___ ? = 
+
+Simple Location has the concept of Providers. Providers are an abstract class that you can implement to take information from one format into the one Simple Location understands.
+The plugin offers providers for:
+* Geolocation - Looking up an address from coordinates or vice versa
+* Location - By default this uses your browser to lookup your location but you can alternatively tap into a service to get your current location, perhaps from your phone
+* Weather - Retrieves weather based on location or station ID
+* Map - Provides maps for display
+
 == Upgrade Notice ==
+
+= 3.4.0 =
+
+Hardcoded and filtered options for new providers have been replaced by a provider registration function with the strings and slug for the provider set inside the provider itself.
+
+= 3.0.0 =
 
 Recommend backup before upgrade to Version 3.0.0 due to the start of venue support. Full location data will not be saved in the post and old posts will be converted. The display name will be saved if set, otherwise a display name will be set from the coordinates. An API key
 will now be required to show maps for services that require API keys.
 
 == Changelog ==
+
+= 3.4.0 ( 2018-xx-xx ) =
+* Fix for incorrect return when there is an error
+* Nominatim began to block reverse traffic so added additional options for reverse lookup.
+* Map Providers and Geo Providers are now separated
+* Unload Jetpack Geo Location which was added unknown to me in 2017. However added compatibility functions to ensure functionality matches
+* Declares post-type support for geo-location which is something the JetPack plugin does
+* Adds location meta tags
+* Add sanitize function that ensures geo_public is always saved as an integer
+* Empty address now causes plugin to display coordinates if not private
+* Provider registration now done by function as opposed to filter
+* Mapquests hosted version of Nominatim now offered but requires API Key
+* Mapquest Static Maps now a supported map provider
+* HERE Maps is now a supported map provider
+* Google is now a supported reverse lookup provider
+* Bing is now a supported reverse lookup provider
 
 = 3.3.8 ( 2018-05-27 ) =
 * Fix for jsonFeed error

--- a/simple-location.php
+++ b/simple-location.php
@@ -3,7 +3,7 @@
  * Plugin Name: Simple Location
  * Plugin URI: https://wordpress.org/plugins/simple-location/
  * Description: Adds Location to WordPress
- * Version: 3.3.8
+ * Version: 3.4.0
  * Author: David Shanske
  * Author URI: https://david.shanske.com
  * Text Domain: simple-location
@@ -20,7 +20,7 @@ register_deactivation_hook( __FILE__, array( 'Simple_Location_Plugin', 'deactiva
 
 
 class Simple_Location_Plugin {
-	public static $version = '3.3.7';
+	public static $version = '3.4.0';
 
 	public static function activate() {
 		require_once plugin_dir_path( __FILE__ ) . 'includes/class-geo-data.php';
@@ -30,6 +30,18 @@ class Simple_Location_Plugin {
 
 	public static function deactivate() {
 		flush_rewrite_rules();
+	}
+
+	public static function load( $files ) {
+		if ( empty( $files ) ) {
+			return;
+		}
+		$path = plugin_dir_path( __FILE__ ) . 'includes/';
+		foreach ( $files as $file ) {
+			if ( file_exists( $path . $file ) ) {
+				require_once( $path . $file );
+			}
+		}
 	}
 
 	public static function init() {
@@ -45,58 +57,38 @@ class Simple_Location_Plugin {
 		// Add Privacy Policy
 		add_action( 'admin_init', array( 'Simple_Location_Plugin', 'privacy_declaration' ) );
 
-		// Register Metadata Functions
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-geo-data.php';
+		// Core Load Files
+		$core = array(
+			'class-geo-data.php', // Register Metadata Functions
+			'class-venue-taxonomy.php', // Venue Taxonomy
+			'class-sloc-provider.php', // Base Provider Class
+			'class-map-provider.php', // Map Provider Class
+			'class-geo-provider.php', // Geo Provider Class
+			'class-weather-provider.php', // Weather Provider Class
+			'class-location-provider.php', // Location Provider Class
+			'class-sloc-weather-widget.php', // Weather Widget
+			'class-sloc-lastseen-widget.php', // Last Location Seen Widget
+			'class-rest-geo.php', // REST endpoint for Geo
+			'class-loc-config.php', // Configuration and Settings Page
+			'class-loc-metabox.php', // Location Metabox
+			'class-loc-view.php', // Location View functionality
+			'class-timezone-result.php',
+			'class-loc-timezone.php', 
+			'class-post-timezone.php'
+		);
 
-		// Venue Taxonomy
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-venue-taxonomy.php';
-
-		// Provider Class
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-sloc-provider.php';
-
-		// Map Provider Class
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-map-provider.php';
-
-		// Geo Provider Class
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-geo-provider.php';
-
-		// Weather Provider Class
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-weather-provider.php';
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-weather-provider-openweathermap.php';
-
-		// Weather Widget
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-sloc-weather-widget.php';
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-sloc-lastseen-widget.php';
+		// Load Core Files
+		self::load( $core );
 		add_action( 'widgets_init', array( 'Simple_Location_Plugin', 'widgets_init' ) );
-
-		// Map Providers
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-map-provider-mapbox.php';
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-map-provider-google.php';
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-map-provider-bing.php';
-
-		// Geo Providers
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-geo-provider-nominatim.php';
-
-		// Location Provider
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-location-provider.php';
-
-		// API Endpoint under construction
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-rest-geo.php';
-		$geo_api = new REST_Geo();
-
-		// Configuration Functions
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-loc-config.php';
-
-		// Add Location Post Meta
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-loc-metabox.php';
-
-		// Add Location Display Functions
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-loc-view.php';
-
-		// Timezone Functions
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-timezone-result.php';
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-loc-timezone.php';
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-post-timezone.php';
+		// Load Providers
+		$providers = array(
+			'class-weather-provider-openweathermap.php',
+			'class-map-provider-mapbox.php',
+			'class-map-provider-google.php',
+			'class-map-provider-bing.php',
+			'class-geo-provider-nominatim.php'
+		);
+		self::load( $providers );
 
 	}
 

--- a/simple-location.php
+++ b/simple-location.php
@@ -52,6 +52,9 @@ class Simple_Location_Plugin {
 		require_once plugin_dir_path( __FILE__ ) . 'includes/class-venue-taxonomy.php';
 
 		// Map Provider Class
+		require_once plugin_dir_path( __FILE__ ) . 'includes/class-map-provider.php';
+
+		// Geo Provider Class
 		require_once plugin_dir_path( __FILE__ ) . 'includes/class-geo-provider.php';
 
 		// Weather Provider Class
@@ -64,9 +67,12 @@ class Simple_Location_Plugin {
 		add_action( 'widgets_init', array( 'Simple_Location_Plugin', 'widgets_init' ) );
 
 		// Map Providers
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-geo-provider-osm.php';
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-geo-provider-google.php';
-		require_once plugin_dir_path( __FILE__ ) . 'includes/class-geo-provider-bing.php';
+		require_once plugin_dir_path( __FILE__ ) . 'includes/class-map-provider-mapbox.php';
+		require_once plugin_dir_path( __FILE__ ) . 'includes/class-map-provider-google.php';
+		require_once plugin_dir_path( __FILE__ ) . 'includes/class-map-provider-bing.php';
+
+		// Geo Providers
+		require_once plugin_dir_path( __FILE__ ) . 'includes/class-geo-provider-nominatim.php';
 
 		// Location Provider
 		require_once plugin_dir_path( __FILE__ ) . 'includes/class-location-provider.php';

--- a/simple-location.php
+++ b/simple-location.php
@@ -90,7 +90,7 @@ class Simple_Location_Plugin {
 			'class-map-provider-here.php',
 			'class-geo-provider-nominatim.php',
 			'class-geo-provider-google.php',
-			'class-geo-provider-bing.php'
+			'class-geo-provider-bing.php',
 		);
 		self::load( $providers );
 

--- a/simple-location.php
+++ b/simple-location.php
@@ -89,6 +89,8 @@ class Simple_Location_Plugin {
 			'class-map-provider-mapquest.php',
 			'class-map-provider-here.php',
 			'class-geo-provider-nominatim.php',
+			'class-geo-provider-google.php',
+			'class-geo-provider-bing.php'
 		);
 		self::load( $providers );
 

--- a/simple-location.php
+++ b/simple-location.php
@@ -51,6 +51,9 @@ class Simple_Location_Plugin {
 		// Venue Taxonomy
 		require_once plugin_dir_path( __FILE__ ) . 'includes/class-venue-taxonomy.php';
 
+		// Provider Class
+		require_once plugin_dir_path( __FILE__ ) . 'includes/class-sloc-provider.php';
+
 		// Map Provider Class
 		require_once plugin_dir_path( __FILE__ ) . 'includes/class-map-provider.php';
 

--- a/simple-location.php
+++ b/simple-location.php
@@ -39,7 +39,7 @@ class Simple_Location_Plugin {
 		$path = plugin_dir_path( __FILE__ ) . 'includes/';
 		foreach ( $files as $file ) {
 			if ( file_exists( $path . $file ) ) {
-				require_once( $path . $file );
+				require_once $path . $file;
 			}
 		}
 	}
@@ -73,8 +73,8 @@ class Simple_Location_Plugin {
 			'class-loc-metabox.php', // Location Metabox
 			'class-loc-view.php', // Location View functionality
 			'class-timezone-result.php',
-			'class-loc-timezone.php', 
-			'class-post-timezone.php'
+			'class-loc-timezone.php',
+			'class-post-timezone.php',
 		);
 
 		// Load Core Files
@@ -86,7 +86,9 @@ class Simple_Location_Plugin {
 			'class-map-provider-mapbox.php',
 			'class-map-provider-google.php',
 			'class-map-provider-bing.php',
-			'class-geo-provider-nominatim.php'
+			'class-map-provider-mapquest.php',
+			'class-map-provider-here.php',
+			'class-geo-provider-nominatim.php',
 		);
 		self::load( $providers );
 


### PR DESCRIPTION
* Fix for incorrect return when there is an error
* Nominatim began to block reverse traffic so added additional options for reverse lookup.
* Map Providers and Geo Providers are now separated
* Unload Jetpack Geo Location which was added unknown to me in 2017. However added compatibility functions to ensure functionality matches
* Declares post-type support for geo-location which is something the JetPack plugin does
* Adds location meta tags
* Add sanitize function that ensures geo_public is always saved as an integer
* Empty address now causes plugin to display coordinates if not private
* Provider registration now done by function as opposed to filter
* Mapquests hosted version of Nominatim now offered but requires API Key
* Mapquest Static Maps now a supported map provider
* HERE Maps is now a supported map provider
* Google is now a supported reverse lookup provider
* Bing is now a supported reverse lookup provider
